### PR TITLE
Fix reference to getRuntimeContextEnv

### DIFF
--- a/cloudflare/dostub.go
+++ b/cloudflare/dostub.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"syscall/js"
 
+	"github.com/syumai/workers/cloudflare/internal/cfruntimecontext"
 	"github.com/syumai/workers/internal/jshttp"
 	"github.com/syumai/workers/internal/jsutil"
 )
@@ -20,7 +21,7 @@ type DurableObjectNamespace struct {
 // This binding must be defined in the `wrangler.toml` file. The method will
 // return an `error` when there is no binding defined by `varName`.
 func NewDurableObjectNamespace(ctx context.Context, varName string) (*DurableObjectNamespace, error) {
-	inst := getRuntimeContextEnv(ctx).Get(varName)
+	inst := cfruntimecontext.GetRuntimeContextEnv(ctx).Get(varName)
 	if inst.IsUndefined() {
 		return nil, fmt.Errorf("%s is undefined", varName)
 	}


### PR DESCRIPTION
This is a tiny PR, fixing broken reference to `getRuntimeContextEnv` when using code in the `cloudflare` directory.