### PR TITLE
commonize ToJSResponse func logic

### DIFF
--- a/cloudflare/cache/method.go
+++ b/cloudflare/cache/method.go
@@ -9,22 +9,6 @@ import (
 	"github.com/syumai/workers/internal/jsutil"
 )
 
-// toJSResponse converts *http.Response to JS Response
-func toJSResponse(res *http.Response) js.Value {
-	status := res.StatusCode
-	if status == 0 {
-		status = http.StatusOK
-	}
-	respInit := jsutil.NewObject()
-	respInit.Set("status", status)
-	respInit.Set("statusText", http.StatusText(status))
-	respInit.Set("headers", jshttp.ToJSHeader(res.Header))
-
-	readableStream := jsutil.ConvertReaderToReadableStream(res.Body)
-
-	return jsutil.ResponseClass.New(readableStream, respInit)
-}
-
 // Put attempts to add a response to the cache, using the given request as the key.
 // Returns an error for the following conditions
 // - the request passed is a method other than GET.
@@ -32,7 +16,7 @@ func toJSResponse(res *http.Response) js.Value {
 // - Cache-Control instructs not to cache or if the response is too large.
 // docs: https://developers.cloudflare.com/workers/runtime-apis/cache/#put
 func (c *Cache) Put(req *http.Request, res *http.Response) error {
-	_, err := jsutil.AwaitPromise(c.instance.Call("put", jshttp.ToJSRequest(req), toJSResponse(res)))
+	_, err := jsutil.AwaitPromise(c.instance.Call("put", jshttp.ToJSRequest(req), jshttp.ToJSResponse(res)))
 	if err != nil {
 		return err
 	}

--- a/handler.go
+++ b/handler.go
@@ -67,7 +67,8 @@ func handleRequest(reqObj js.Value, runtimeCtxObj js.Value) (js.Value, error) {
 		defer writer.Close()
 		httpHandler.ServeHTTP(w, req)
 	}()
-	return jshttp.ToJSResponse(w)
+	<-w.ReadyCh
+	return w.ToJSResponse(), nil
 }
 
 // Server serves http.Handler on Cloudflare Workers.

--- a/internal/jshttp/responsewriter.go
+++ b/internal/jshttp/responsewriter.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"sync"
+	"syscall/js"
 )
 
 type ResponseWriterBuffer struct {
@@ -35,4 +36,10 @@ func (w *ResponseWriterBuffer) Header() http.Header {
 
 func (w *ResponseWriterBuffer) WriteHeader(statusCode int) {
 	w.StatusCode = statusCode
+}
+
+// ToJSResponse converts *ResponseWriterBuffer to JavaScript sides Response.
+//   - Response: https://developer.mozilla.org/docs/Web/API/Response
+func (w *ResponseWriterBuffer) ToJSResponse() js.Value {
+	return newJSResponse(w.StatusCode, w.HeaderValue, w.Reader)
 }


### PR DESCRIPTION
# What

* commonize ToJSResponse func.
* move `<-w.Ready` to outside of ToJSResponse func.

# Motivation

Because the cache package and jshttp package share almost the same logic for response conversion.