### PR TITLE
update worker.mjs

### DIFF
--- a/examples/assets/shim.mjs
+++ b/examples/assets/shim.mjs
@@ -1,0 +1,24 @@
+import "./polyfill_performance.js";
+import "./wasm_exec.js";
+
+const go = new Go();
+
+let mod;
+
+export function init(m) {
+    mod = m;
+}
+
+async function run() {
+    const readyPromise = new Promise((resolve) => {
+        globalThis.ready = resolve;
+    });
+    const instance = new WebAssembly.Instance(mod, go.importObject);
+    go.run(instance);
+    await readyPromise;
+}
+
+export async function fetch(req, env, ctx) {
+    await run();
+    return handleRequest(req, { env, ctx });
+}

--- a/examples/basic-auth-proxy/worker.mjs
+++ b/examples/basic-auth-proxy/worker.mjs
@@ -1,22 +1,6 @@
-import "../assets/polyfill_performance.js";
-import "../assets/wasm_exec.js";
+import * as imports from "../assets/shim.mjs";
 import mod from "./dist/app.wasm";
 
-const go = new Go();
+imports.init(mod);
 
-const readyPromise = new Promise((resolve) => {
-  globalThis.ready = resolve;
-});
-
-const load = WebAssembly.instantiate(mod, go.importObject).then((instance) => {
-  go.run(instance);
-  return instance;
-});
-
-export default {
-  async fetch(req, env, ctx) {
-    await load;
-    await readyPromise;
-    return handleRequest(req, { env, ctx });
-  }
-}
+export default { fetch: imports.fetch }

--- a/examples/cache/worker.mjs
+++ b/examples/cache/worker.mjs
@@ -1,22 +1,6 @@
-import "../assets/polyfill_performance.js";
-import "../assets/wasm_exec.js";
+import * as imports from "../assets/shim.mjs";
 import mod from "./dist/app.wasm";
 
-const go = new Go();
+imports.init(mod);
 
-const readyPromise = new Promise((resolve) => {
-  globalThis.ready = resolve;
-});
-
-const load = WebAssembly.instantiate(mod, go.importObject).then((instance) => {
-  go.run(instance);
-  return instance;
-});
-
-export default {
-  async fetch(req, env, ctx) {
-    await load;
-    await readyPromise;
-    return handleRequest(req, { env, ctx });
-  }
-}
+export default { fetch: imports.fetch }

--- a/examples/d1-blog-server/worker.mjs
+++ b/examples/d1-blog-server/worker.mjs
@@ -1,22 +1,6 @@
-import "../assets/polyfill_performance.js";
-import "../assets/wasm_exec.js";
+import * as imports from "../assets/shim.mjs";
 import mod from "./dist/app.wasm";
 
-const go = new Go();
+imports.init(mod);
 
-const readyPromise = new Promise((resolve) => {
-  globalThis.ready = resolve;
-});
-
-const load = WebAssembly.instantiate(mod, go.importObject).then((instance) => {
-  go.run(instance);
-  return instance;
-});
-
-export default {
-  async fetch(req, env, ctx) {
-    await load;
-    await readyPromise;
-    return handleRequest(req, { env, ctx });
-  }
-}
+export default { fetch: imports.fetch }

--- a/examples/durable-object-counter/worker.mjs
+++ b/examples/durable-object-counter/worker.mjs
@@ -1,25 +1,9 @@
-import "../assets/polyfill_performance.js";
-import "../assets/wasm_exec.js";
+import * as imports from "../assets/shim.mjs";
 import mod from "./dist/app.wasm";
 
-const go = new Go();
+imports.init(mod);
 
-const readyPromise = new Promise((resolve) => {
-  globalThis.ready = resolve;
-});
-
-const load = WebAssembly.instantiate(mod, go.importObject).then((instance) => {
-  go.run(instance);
-  return instance;
-});
-
-export default {
-  async fetch(req, env, ctx) {
-    await load;
-    await readyPromise;
-    return handleRequest(req, { env, ctx });
-  }
-}
+export default { fetch: imports.fetch }
 
 // Durable Object
 

--- a/examples/env/worker.mjs
+++ b/examples/env/worker.mjs
@@ -1,22 +1,6 @@
-import "../assets/polyfill_performance.js";
-import "../assets/wasm_exec.js";
+import * as imports from "../assets/shim.mjs";
 import mod from "./dist/app.wasm";
 
-const go = new Go();
+imports.init(mod);
 
-const readyPromise = new Promise((resolve) => {
-  globalThis.ready = resolve;
-});
-
-const load = WebAssembly.instantiate(mod, go.importObject).then((instance) => {
-  go.run(instance);
-  return instance;
-});
-
-export default {
-  async fetch(req, env, ctx) {
-    await load;
-    await readyPromise;
-    return handleRequest(req, { env, ctx });
-  }
-}
+export default { fetch: imports.fetch }

--- a/examples/fetch-event/worker.mjs
+++ b/examples/fetch-event/worker.mjs
@@ -1,22 +1,6 @@
-import "../assets/polyfill_performance.js";
-import "../assets/wasm_exec.js";
+import * as imports from "../assets/shim.mjs";
 import mod from "./dist/app.wasm";
 
-const go = new Go();
+imports.init(mod);
 
-const readyPromise = new Promise((resolve) => {
-  globalThis.ready = resolve;
-});
-
-const load = WebAssembly.instantiate(mod, go.importObject).then((instance) => {
-  go.run(instance);
-  return instance;
-});
-
-export default {
-  async fetch(req, env, ctx) {
-    await load;
-    await readyPromise;
-    return handleRequest(req, { env, ctx });
-  }
-}
+export default { fetch: imports.fetch }

--- a/examples/fetch/worker.mjs
+++ b/examples/fetch/worker.mjs
@@ -1,22 +1,6 @@
-import "../assets/polyfill_performance.js";
-import "../assets/wasm_exec.js";
+import * as imports from "../assets/shim.mjs";
 import mod from "./dist/app.wasm";
 
-const go = new Go();
+imports.init(mod);
 
-const readyPromise = new Promise((resolve) => {
-  globalThis.ready = resolve;
-});
-
-const load = WebAssembly.instantiate(mod, go.importObject).then((instance) => {
-  go.run(instance);
-  return instance;
-});
-
-export default {
-  async fetch(req, env, ctx) {
-    await load;
-    await readyPromise;
-    return handleRequest(req, { env, ctx });
-  }
-}
+export default { fetch: imports.fetch }

--- a/examples/hello/worker.mjs
+++ b/examples/hello/worker.mjs
@@ -1,22 +1,6 @@
-import "../assets/polyfill_performance.js";
-import "../assets/wasm_exec.js";
+import * as imports from "../assets/shim.mjs";
 import mod from "./dist/app.wasm";
 
-const go = new Go();
+imports.init(mod);
 
-const readyPromise = new Promise((resolve) => {
-  globalThis.ready = resolve;
-});
-
-const load = WebAssembly.instantiate(mod, go.importObject).then((instance) => {
-  go.run(instance);
-  return instance;
-});
-
-export default {
-  async fetch(req, env, ctx) {
-    await load;
-    await readyPromise;
-    return handleRequest(req, { env, ctx });
-  }
-}
+export default { fetch: imports.fetch }

--- a/examples/r2-image-server/worker.mjs
+++ b/examples/r2-image-server/worker.mjs
@@ -1,22 +1,6 @@
-import "../assets/polyfill_performance.js";
-import "../assets/wasm_exec.js";
+import * as imports from "../assets/shim.mjs";
 import mod from "./dist/app.wasm";
 
-const go = new Go();
+imports.init(mod);
 
-const readyPromise = new Promise((resolve) => {
-  globalThis.ready = resolve;
-});
-
-const load = WebAssembly.instantiate(mod, go.importObject).then((instance) => {
-  go.run(instance);
-  return instance;
-});
-
-export default {
-  async fetch(req, env, ctx) {
-    await load;
-    await readyPromise;
-    return handleRequest(req, { env, ctx });
-  }
-}
+export default { fetch: imports.fetch }

--- a/examples/r2-image-viewer/worker.mjs
+++ b/examples/r2-image-viewer/worker.mjs
@@ -1,22 +1,6 @@
-import "../assets/polyfill_performance.js";
-import "../assets/wasm_exec.js";
+import * as imports from "../assets/shim.mjs";
 import mod from "./dist/app.wasm";
 
-const go = new Go();
+imports.init(mod);
 
-const readyPromise = new Promise((resolve) => {
-  globalThis.ready = resolve;
-});
-
-const load = WebAssembly.instantiate(mod, go.importObject).then((instance) => {
-  go.run(instance);
-  return instance;
-});
-
-export default {
-  async fetch(req, env, ctx) {
-    await load;
-    await readyPromise;
-    return handleRequest(req, { env, ctx });
-  }
-}
+export default { fetch: imports.fetch }

--- a/examples/service-bindings/worker.mjs
+++ b/examples/service-bindings/worker.mjs
@@ -1,22 +1,6 @@
-import "../assets/polyfill_performance.js";
-import "../assets/wasm_exec.js";
+import * as imports from "../assets/shim.mjs";
 import mod from "./dist/app.wasm";
 
-const go = new Go();
+imports.init(mod);
 
-const readyPromise = new Promise((resolve) => {
-  globalThis.ready = resolve;
-});
-
-const load = WebAssembly.instantiate(mod, go.importObject).then((instance) => {
-  go.run(instance);
-  return instance;
-});
-
-export default {
-  async fetch(req, env, ctx) {
-    await load;
-    await readyPromise;
-    return handleRequest(req, { env, ctx });
-  }
-}
+export default { fetch: imports.fetch }

--- a/examples/simple-json-server/worker.mjs
+++ b/examples/simple-json-server/worker.mjs
@@ -1,22 +1,6 @@
-import "../assets/polyfill_performance.js";
-import "../assets/wasm_exec.js";
+import * as imports from "../assets/shim.mjs";
 import mod from "./dist/app.wasm";
 
-const go = new Go();
+imports.init(mod);
 
-const readyPromise = new Promise((resolve) => {
-  globalThis.ready = resolve;
-});
-
-const load = WebAssembly.instantiate(mod, go.importObject).then((instance) => {
-  go.run(instance);
-  return instance;
-});
-
-export default {
-  async fetch(req, env, ctx) {
-    await load;
-    await readyPromise;
-    return handleRequest(req, { env, ctx });
-  }
-}
+export default { fetch: imports.fetch }


### PR DESCRIPTION
# What

* update worker.mjs in examples based on https://github.com/syumai/worker-template-go/pull/4.
  - split shim.mjs and worker.mjs

# Motivation

* To simplify worker.mjs entrypoint and commonize `run` logic in shim.mjs.
