### PR TITLE
move cron into cloudflare

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 * [x] D1 (alpha)
 * [x] Environment variables
 * [x] FetchEvent
+* [x] Cron Triggers
 
 ## Installation
 

--- a/cloudflare/cron/cron.go
+++ b/cloudflare/cron/cron.go
@@ -1,4 +1,4 @@
-package workers
+package cron
 
 import (
 	"context"

--- a/examples/cron/main.go
+++ b/examples/cron/main.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/syumai/workers"
 	"github.com/syumai/workers/cloudflare"
+	"github.com/syumai/workers/cloudflare/cron"
 )
 
-func task(ctx context.Context, event workers.CronEvent) error {
+func task(ctx context.Context, event cron.CronEvent) error {
 	fmt.Println(cloudflare.Getenv(ctx, "HELLO"))
 
 	if event.ScheduledTime.Minute()%2 == 0 {
@@ -20,5 +20,5 @@ func task(ctx context.Context, event workers.CronEvent) error {
 }
 
 func main() {
-	workers.ScheduleTask(task)
+	cron.ScheduleTask(task)
 }

--- a/examples/cron/main.go
+++ b/examples/cron/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/syumai/workers/cloudflare/cron"
 )
 
-func task(ctx context.Context, event cron.CronEvent) error {
+func task(ctx context.Context, event cron.Event) error {
 	fmt.Println(cloudflare.Getenv(ctx, "HELLO"))
 
 	if event.ScheduledTime.Minute()%2 == 0 {

--- a/examples/cron/main.go
+++ b/examples/cron/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/syumai/workers/cloudflare/cron"
 )
 
-func task(ctx context.Context, event cron.Event) error {
+func task(ctx context.Context, event *cron.Event) error {
 	fmt.Println(cloudflare.Getenv(ctx, "HELLO"))
 
 	if event.ScheduledTime.Minute()%2 == 0 {


### PR DESCRIPTION
# What

* split cron package and moved into cloudflare package.
* rename some types in cron package.
  - because it includes `cron` in package name.

# Motivation

* `Cron Trigger` feature is considered as `cloudflare` specific feature, so it's better to be placed in cloudflare package.

