### PR TITLE
use workers-assets-gen command in pages functions example

### DIFF
--- a/_examples/pages-functions/Makefile
+++ b/_examples/pages-functions/Makefile
@@ -4,7 +4,7 @@ dev:
 
 .PHONY: build
 build:
-	mkdir -p build
+	go run ../../cmd/workers-assets-gen
 	tinygo build -o ./build/app.wasm -target wasm ./...
 
 .PHONY: publish

--- a/_examples/pages-functions/functions/hello.js
+++ b/_examples/pages-functions/functions/hello.js
@@ -1,24 +1,6 @@
-import "../../assets/polyfill_performance.js";
-import "../../assets/wasm_exec.js";
 import mod from "../build/app.wasm";
+import * as imports from "../build/shim.mjs"
 
-const go = new Go();
+imports.init(mod);
 
-const readyPromise = new Promise((resolve) => {
-  globalThis.ready = resolve;
-});
-
-const load = WebAssembly.instantiate(mod, go.importObject).then((instance) => {
-  go.run(instance);
-  return instance;
-});
-
-export const onRequest = async (ctx) => {
-  await load;
-  await readyPromise;
-  const {
-    request,
-    env,
-  } = ctx;
-  return handleRequest(request, { env, ctx });
-}
+export const onRequest = imports.onRequest;

--- a/_examples/pages-functions/wrangler.toml
+++ b/_examples/pages-functions/wrangler.toml
@@ -1,4 +1,5 @@
 name = "pages-functions"
+compatibility_date = "2023-04-30"
 
 [build]
 command = "make build"

--- a/cmd/workers-assets-gen/assets/common/shim.mjs
+++ b/cmd/workers-assets-gen/assets/common/shim.mjs
@@ -27,3 +27,10 @@ export async function scheduled(event, env, ctx) {
   await run();
   return runScheduler(event, { env, ctx });
 }
+
+// onRequest handles request to Cloudflare Pages
+export async function onRequest(ctx) {
+  await run();
+  const { request, env } = ctx;
+  return handleRequest(request, { env, ctx });
+}


### PR DESCRIPTION
# What

* add `onRequest` handler to shim.mjs and exported it.
* use `workers-assets-gen` command in pages functions example.

# Motivation

* To resolve #50.

