### PR TITLE
added pages template

### DIFF
--- a/_templates/cloudflare/pages-tinygo/Makefile
+++ b/_templates/cloudflare/pages-tinygo/Makefile
@@ -1,0 +1,12 @@
+.PHONY: dev
+dev:
+	wrangler pages dev ./pages
+
+.PHONY: build
+build:
+	go run github.com/syumai/workers/cmd/workers-assets-gen@latest
+	tinygo build -o ./build/app.wasm -target wasm ./...
+
+.PHONY: deploy
+deploy:
+	wrangler pages deploy ./pages

--- a/_templates/cloudflare/pages-tinygo/README.md
+++ b/_templates/cloudflare/pages-tinygo/README.md
@@ -1,0 +1,61 @@
+# pages-tinygo
+
+- A template for starting a Cloudflare Pages Functions project with tinygo.
+- This template uses the [`workers`](https://github.com/syumai/workers) package to run.
+
+## Usage
+
+- `main.go` includes a [chi](https://github.com/go-chi/chi) HTTP router implementation with three different routes. Feel free to edit this code and implement your own HTTP router.
+
+## Requirements
+
+- Node.js
+- [wrangler](https://developers.cloudflare.com/workers/wrangler/)
+  - just run `npm install -g wrangler`
+- tinygo
+
+## Getting Started
+
+```console
+wrangler generate my-app syumai/workers/_templates/cloudflare/pages-tinygo
+cd my-app
+go mod init
+go mod tidy
+make dev # start running dev server
+curl http://localhost:8787/api/hello # outputs "Hello, Pages Functions!"
+```
+
+## Development
+
+### Commands
+
+```
+make dev     # run dev server
+make build   # build Go Wasm binary
+make deploy # deploy worker
+```
+
+### Testing dev server
+
+- You can send HTTP requests using tools like curl.
+
+```
+$ curl http://localhost:8787/api/hello
+Hello, Pages Functions!
+```
+
+```
+$ curl http://localhost:8787/api/hello?name=Example
+Hello, Example!
+```
+
+```
+$ curl http://localhost:8787/api/hello2
+Hello, Hello world!
+```
+
+```
+$ curl http://localhost:8787/api/hello3
+Hello, Hello, Hello world!
+```
+

--- a/_templates/cloudflare/pages-tinygo/functions/api/[[routes]].mjs
+++ b/_templates/cloudflare/pages-tinygo/functions/api/[[routes]].mjs
@@ -1,0 +1,6 @@
+import mod from "../../build/app.wasm";
+import * as imports from "../../build/shim.mjs"
+
+imports.init(mod);
+
+export const onRequest = imports.onRequest;

--- a/_templates/cloudflare/pages-tinygo/go.mod
+++ b/_templates/cloudflare/pages-tinygo/go.mod
@@ -1,0 +1,9 @@
+module github.com/syumai/workers/_examples/pages-functions
+
+go 1.18
+
+require github.com/syumai/workers v0.0.0
+
+require github.com/go-chi/chi/v5 v5.0.8 // indirect
+
+replace github.com/syumai/workers => ../../

--- a/_templates/cloudflare/pages-tinygo/go.sum
+++ b/_templates/cloudflare/pages-tinygo/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.0.8 h1:lD+NLqFcAi1ovnVZpsnObHGW4xb4J8lNmoYVfECH1Y0=
+github.com/go-chi/chi/v5 v5.0.8/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=

--- a/_templates/cloudflare/pages-tinygo/main.go
+++ b/_templates/cloudflare/pages-tinygo/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/syumai/workers"
+)
+
+func main() {
+	r := chi.NewRouter()
+	r.Route("/api", func(r chi.Router) {
+		r.Get("/hello", func(w http.ResponseWriter, req *http.Request) {
+			name := req.URL.Query().Get("name")
+			if name == "" {
+				name = "Pages Functions"
+			}
+			fmt.Fprintf(w, "Hello, %s!", name)
+		})
+		r.Get("/hello2", func(w http.ResponseWriter, req *http.Request) {
+			fmt.Fprintf(w, "Hello, Hello world!")
+		})
+		r.Get("/hello3", func(w http.ResponseWriter, req *http.Request) {
+			fmt.Fprintf(w, "Hello, Hello, Hello world!")
+		})
+	})
+	workers.Serve(r)
+}

--- a/_templates/cloudflare/pages-tinygo/pages/index.html
+++ b/_templates/cloudflare/pages-tinygo/pages/index.html
@@ -8,7 +8,7 @@
       <a href="/api/hello">/api/hello</a>
     </p>
     <p>
-      <a href="/api/hello?name=syumai">/api/hello?name=Example</a>
+      <a href="/api/hello?name=Example">/api/hello?name=Example</a>
     </p>
     <p>
       <a href="/api/hello2">/api/hello2</a>

--- a/_templates/cloudflare/pages-tinygo/pages/index.html
+++ b/_templates/cloudflare/pages-tinygo/pages/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <p>
+      <a href="/api/hello">/api/hello</a>
+    </p>
+    <p>
+      <a href="/api/hello?name=syumai">/api/hello?name=Example</a>
+    </p>
+    <p>
+      <a href="/api/hello2">/api/hello2</a>
+    </p>
+    <p>
+      <a href="/api/hello3">/api/hello3</a>
+    </p>
+  </body>
+</html>

--- a/_templates/cloudflare/pages-tinygo/wrangler.toml
+++ b/_templates/cloudflare/pages-tinygo/wrangler.toml
@@ -1,0 +1,6 @@
+name = "pages-functions-tinygo"
+compatibility_date = "2023-04-30"
+
+[build]
+command = "make build"
+


### PR DESCRIPTION
# What

Added pages and functions tinygo template for use with wrangler generate.

# Motivation

[Github issue to add template](https://github.com/syumai/workers/issues/51)

I was unable to test yet due to being unsure how to test wrangler generate with an alternative branch or local template. 
I also deleted go.mod and go.sum as go.mod referenced the old example module and the other templates did not have these. I'm unsure if this will affect the template or if it will affect go-chi being automatically installed.


