### PR TITLE
use gonew command to initialize project

### DIFF
--- a/_templates/cloudflare/pages-tinygo/README.md
+++ b/_templates/cloudflare/pages-tinygo/README.md
@@ -16,10 +16,18 @@
 
 ## Getting Started
 
+* If not already installed, please install the [gonew](https://pkg.go.dev/golang.org/x/tools/cmd/gonew) command.
+
 ```console
-wrangler generate my-app syumai/workers/_templates/cloudflare/pages-tinygo
+go install golang.org/x/tools/cmd/gonew@latest
+```
+
+* Create a new project using this template.
+  - Second argument passed to `gonew` is a module path of your new app.
+
+```console
+gonew github.com/syumai/workers/_templates/cloudflare/pages-tinygo your.module/my-app # e.g. github.com/syumai/my-app
 cd my-app
-go mod init
 go mod tidy
 make dev # start running dev server
 curl http://localhost:8787/api/hello # outputs "Hello, Pages Functions!"

--- a/_templates/cloudflare/pages-tinygo/go.mod
+++ b/_templates/cloudflare/pages-tinygo/go.mod
@@ -1,4 +1,4 @@
-module github.com/syumai/workers/_examples/pages-functions
+module github.com/syumai/workers/_examples/pages-tinygo
 
 go 1.18
 

--- a/_templates/cloudflare/worker-go/README.md
+++ b/_templates/cloudflare/worker-go/README.md
@@ -21,10 +21,20 @@
 
 ## Getting Started
 
+## Getting Started
+
+* If not already installed, please install the [gonew](https://pkg.go.dev/golang.org/x/tools/cmd/gonew) command.
+
 ```console
-wrangler generate my-app syumai/workers/_templates/cloudflare/worker-go
+go install golang.org/x/tools/cmd/gonew@latest
+```
+
+* Create a new project using this template.
+  - Second argument passed to `gonew` is a module path of your new app.
+
+```console
+gonew github.com/syumai/workers/_templates/cloudflare/worker-go your.module/my-app # e.g. github.com/syumai/my-app
 cd my-app
-go mod init
 go mod tidy
 make dev # start running dev server
 curl http://localhost:8787/hello # outputs "Hello!"

--- a/_templates/cloudflare/worker-go/go.mod
+++ b/_templates/cloudflare/worker-go/go.mod
@@ -1,0 +1,3 @@
+module github.com/syumai/workers/_templates/cloudflare/worker-go
+
+go 1.21.1

--- a/_templates/cloudflare/worker-tinygo/README.md
+++ b/_templates/cloudflare/worker-tinygo/README.md
@@ -16,10 +16,18 @@
 
 ## Getting Started
 
+* If not already installed, please install the [gonew](https://pkg.go.dev/golang.org/x/tools/cmd/gonew) command.
+
 ```console
-wrangler generate my-app syumai/workers/_templates/cloudflare/worker-tinygo
+go install golang.org/x/tools/cmd/gonew@latest
+```
+
+* Create a new project using this template.
+  - Second argument passed to `gonew` is a module path of your new app.
+
+```console
+gonew github.com/syumai/workers/_templates/cloudflare/worker-tinygo your.module/my-app # e.g. github.com/syumai/my-app
 cd my-app
-go mod init
 go mod tidy
 make dev # start running dev server
 curl http://localhost:8787/hello # outputs "Hello!"

--- a/_templates/cloudflare/worker-tinygo/go.mod
+++ b/_templates/cloudflare/worker-tinygo/go.mod
@@ -1,0 +1,3 @@
+module github.com/syumai/workers/_templates/cloudflare/worker-tinygo
+
+go 1.21.1


### PR DESCRIPTION
# What

* Replace initialization command `wrangler generate` to `gonew`.

# Motivation

* `wrangler generate` has been deprecated.
* `gonew` command seemed appropriate for this use case.
  - https://go.dev/blog/gonew
