### PR TITLE
fix pages example's go.mod

### DIFF
--- a/_templates/cloudflare/pages-tinygo/go.mod
+++ b/_templates/cloudflare/pages-tinygo/go.mod
@@ -1,9 +1,5 @@
 module github.com/syumai/workers/_examples/pages-tinygo
 
-go 1.18
+go 1.21.1
 
-require github.com/syumai/workers v0.0.0
-
-require github.com/go-chi/chi/v5 v5.0.8 // indirect
-
-replace github.com/syumai/workers => ../../
+require github.com/go-chi/chi/v5 v5.0.8

--- a/_templates/cloudflare/pages-tinygo/go.sum
+++ b/_templates/cloudflare/pages-tinygo/go.sum
@@ -1,2 +1,4 @@
 github.com/go-chi/chi/v5 v5.0.8 h1:lD+NLqFcAi1ovnVZpsnObHGW4xb4J8lNmoYVfECH1Y0=
 github.com/go-chi/chi/v5 v5.0.8/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/syumai/workers v0.18.0 h1:RBnOFqghALR0woeCCYumG7Zt7UDFAt51rSQJhd/hJjw=
+github.com/syumai/workers v0.18.0/go.mod h1:ZnqmdiHNBrbxOLrZ/HJ5jzHy6af9cmiNZk10R9NrIEA=


### PR DESCRIPTION
# What

* pages example had too much information.
   - removed unnecessary information

# Motivation

* `go mod tidy` is not working as expected.
