### PR TITLE
update workers-assets-gen cmd in examples to v0.20.0

### DIFF
--- a/_templates/cloudflare/pages-tinygo/Makefile
+++ b/_templates/cloudflare/pages-tinygo/Makefile
@@ -4,7 +4,7 @@ dev:
 
 .PHONY: build
 build:
-	go run github.com/syumai/workers/cmd/workers-assets-gen@v0.18.0
+	go run github.com/syumai/workers/cmd/workers-assets-gen@v0.20.0
 	tinygo build -o ./build/app.wasm -target wasm -no-debug ./...
 
 .PHONY: deploy

--- a/_templates/cloudflare/worker-go/Makefile
+++ b/_templates/cloudflare/worker-go/Makefile
@@ -4,7 +4,7 @@ dev:
 
 .PHONY: build
 build:
-	go run github.com/syumai/workers/cmd/workers-assets-gen@v0.18.0 -mode=go
+	go run github.com/syumai/workers/cmd/workers-assets-gen@v0.20.0 -mode=go
 	GOOS=js GOARCH=wasm go build -o ./build/app.wasm .
 
 .PHONY: deploy

--- a/_templates/cloudflare/worker-tinygo/Makefile
+++ b/_templates/cloudflare/worker-tinygo/Makefile
@@ -4,7 +4,7 @@ dev:
 
 .PHONY: build
 build:
-	go run github.com/syumai/workers/cmd/workers-assets-gen@v0.18.0
+	go run github.com/syumai/workers/cmd/workers-assets-gen@v0.20.0
 	tinygo build -o ./build/app.wasm -target wasm -no-debug ./...
 
 .PHONY: deploy


### PR DESCRIPTION
# What

update workers-assets-gen cmd in examples to v0.20.0.

# Motivation

* performance API polyfill has been removed from generated files.
