### PR TITLE
use go:wasmimport for ready func

### DIFF
--- a/cmd/workers-assets-gen/assets/common/shim.mjs
+++ b/cmd/workers-assets-gen/assets/common/shim.mjs
@@ -13,7 +13,7 @@ globalThis.tryCatch = (fn) => {
   } catch(e) {
     return {
       error: e,
-    }
+    };
   }
 }
 
@@ -22,10 +22,16 @@ export function init(m) {
 }
 
 async function run() {
+  let ready;
   const readyPromise = new Promise((resolve) => {
-    globalThis.ready = resolve;
+    ready = resolve;
   });
-  const instance = new WebAssembly.Instance(mod, go.importObject);
+  const instance = new WebAssembly.Instance(mod, {
+    ...go.importObject,
+    workers: {
+      ready: () => { ready() }
+    },
+  });
   go.run(instance);
   await readyPromise;
 }
@@ -35,7 +41,7 @@ function createRuntimeContext(env, ctx) {
     env,
     ctx,
     connect,
-  }
+  };
 }
 
 export async function fetch(req, env, ctx) {

--- a/handler.go
+++ b/handler.go
@@ -71,6 +71,9 @@ func handleRequest(reqObj js.Value, runtimeCtxObj js.Value) (js.Value, error) {
 	return w.ToJSResponse(), nil
 }
 
+//go:wasmimport workers ready
+func ready()
+
 // Server serves http.Handler on Cloudflare Workers.
 // if the given handler is nil, http.DefaultServeMux will be used.
 func Serve(handler http.Handler) {
@@ -78,6 +81,6 @@ func Serve(handler http.Handler) {
 		handler = http.DefaultServeMux
 	}
 	httpHandler = handler
-	js.Global().Call("ready")
+	ready()
 	select {}
 }


### PR DESCRIPTION
# What

* use  go:wasmimport for ready func which is called by `workers.Serve()`.

# Motivation

* To reduce use of `js.Global()`.
