### PR TITLE
D1 driver would cause panic when QueryContext is called with parameters

### DIFF
--- a/cloudflare/d1/stmt.go
+++ b/cloudflare/d1/stmt.go
@@ -57,7 +57,7 @@ func (s *stmt) Query([]driver.Value) (driver.Rows, error) {
 func (s *stmt) QueryContext(_ context.Context, args []driver.NamedValue) (driver.Rows, error) {
 	argValues := make([]any, len(args))
 	for i, arg := range args {
-		argValues[i] = arg
+		argValues[i] = arg.Value
 	}
 	resultPromise := s.stmtObj.Call("bind", argValues...).Call("all")
 	rowsObj, err := jsutil.AwaitPromise(resultPromise)


### PR DESCRIPTION
# What

I fixed an issue where the D1 driver would cause a panic when QueryContext is called with parameters.
The problem was that QueryContext was attempting to bind driver.NamedValue as JavaScript values, which was bound to fail.
I have updated it to bind driver.NamedValue.Value in the same way that ExecContext does.

# Motivation

Thank you for providing such a wonderful framework.
I hope this fix will be helpful to you.
