### PR TITLE
return fetch body directly

### DIFF
--- a/_examples/basic-auth-proxy/go.mod
+++ b/_examples/basic-auth-proxy/go.mod
@@ -2,9 +2,6 @@ module github.com/syumai/workers/_examples/basic-auth-server
 
 go 1.21.3
 
-require (
-	github.com/syumai/tinyutil v0.3.0
-	github.com/syumai/workers v0.5.1
-)
+require github.com/syumai/workers v0.5.1
 
 replace github.com/syumai/workers => ../../

--- a/_examples/basic-auth-proxy/go.sum
+++ b/_examples/basic-auth-proxy/go.sum
@@ -1,2 +1,0 @@
-github.com/syumai/tinyutil v0.3.0 h1:sgWeE8oQyequIRLNeHZgR1PddpY4mxcdkfMgx2m53IE=
-github.com/syumai/tinyutil v0.3.0/go.mod h1:/owCyUs1bh6tKxH7K1Ze3M/zZtZ+vGrj3h82fgNHDFI=

--- a/cloudflare/kv.go
+++ b/cloudflare/kv.go
@@ -66,7 +66,7 @@ func (kv *KVNamespace) GetReader(key string, opts *KVNamespaceGetOptions) (io.Re
 	if err != nil {
 		return nil, err
 	}
-	return jsutil.ConvertStreamReaderToReader(v.Call("getReader")), nil
+	return jsutil.ConvertReadableStreamToReadCloser(v), nil
 }
 
 // KVNamespaceListOptions represents Cloudflare KV namespace list options.

--- a/cloudflare/r2object.go
+++ b/cloudflare/r2object.go
@@ -54,7 +54,7 @@ func toR2Object(v js.Value) (*R2Object, error) {
 	bodyVal := v.Get("body")
 	var body io.Reader
 	if !bodyVal.IsUndefined() {
-		body = jsutil.ConvertStreamReaderToReader(v.Get("body").Call("getReader"))
+		body = jsutil.ConvertReadableStreamToReadCloser(v.Get("body"))
 	}
 	return &R2Object{
 		instance:       v,

--- a/internal/jshttp/request.go
+++ b/internal/jshttp/request.go
@@ -17,8 +17,7 @@ func ToBody(streamOrNull js.Value) io.ReadCloser {
 	if streamOrNull.IsNull() {
 		return nil
 	}
-	sr := streamOrNull.Call("getReader")
-	return io.NopCloser(jsutil.ConvertStreamReaderToReader(sr))
+	return jsutil.ConvertReadableStreamToReadCloser(streamOrNull)
 }
 
 // ToRequest converts JavaScript sides Request to *http.Request.


### PR DESCRIPTION
# What

* add jsutil.RawJSWriter and use it in jshttp.ResponseWriter.
  - This passes raw JS fetch response body as Cloudflare Worker's response body without using Go's io.Reader.

# Motivation

* To fix #85.

# How to use this feature?

* Please use the `cloudflare/fetch` package and `io.Copy` to implement the proxy.
* See `_examples/basic-auth-proxy/main.go`.