### PR TITLE
Support stream in fetch pkg

### DIFF
--- a/_examples/stream-large-file/.gitignore
+++ b/_examples/stream-large-file/.gitignore
@@ -1,0 +1,3 @@
+build
+node_modules
+.wrangler

--- a/_examples/stream-large-file/Makefile
+++ b/_examples/stream-large-file/Makefile
@@ -1,0 +1,12 @@
+.PHONY: dev
+dev:
+	wrangler dev
+
+.PHONY: build
+build:
+	go run ../../cmd/workers-assets-gen
+	tinygo build -o ./build/app.wasm -target wasm -no-debug ./...
+
+.PHONY: deploy
+deploy:
+	wrangler deploy

--- a/_examples/stream-large-file/README.md
+++ b/_examples/stream-large-file/README.md
@@ -1,0 +1,18 @@
+# stream-large-file
+
+## Development
+
+### Requirements
+
+This project requires these tools to be installed globally.
+
+* wrangler
+* tinygo
+
+### Commands
+
+```
+make dev     # run dev server
+make build   # build Go Wasm binary
+make deploy # deploy worker
+```

--- a/_examples/stream-large-file/go.mod
+++ b/_examples/stream-large-file/go.mod
@@ -1,0 +1,7 @@
+module github.com/syumai/workers/_examples/stream
+
+go 1.21.3
+
+require github.com/syumai/workers v0.0.0
+
+replace github.com/syumai/workers => ../../

--- a/_examples/stream-large-file/go.sum
+++ b/_examples/stream-large-file/go.sum
@@ -1,0 +1,2 @@
+github.com/syumai/workers v0.1.0 h1:z5QfQR2X+PCKzom7RodpI5J4D5YF7NT7Qwzb9AM9dgY=
+github.com/syumai/workers v0.1.0/go.mod h1:alXIDhTyeTwSzh0ZgQ3cb9HQPyyYfIejupE4Z3efr14=

--- a/_examples/stream-large-file/main.go
+++ b/_examples/stream-large-file/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/syumai/workers"
+	"github.com/syumai/workers/cloudflare/fetch"
+)
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		cli := fetch.NewClient().HTTPClient(fetch.RedirectModeFollow)
+		resp, err := cli.Get("http://tyo.download.datapacket.com/1000mb.bin")
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, "err: %v", err)
+			return
+		}
+		defer resp.Body.Close()
+
+		io.Copy(w, resp.Body)
+	})
+	workers.Serve(nil)
+}

--- a/_examples/stream-large-file/wrangler.toml
+++ b/_examples/stream-large-file/wrangler.toml
@@ -1,0 +1,6 @@
+name = "stream-large-file"
+main = "./build/worker.mjs"
+compatibility_date = "2023-12-01"
+
+[build]
+command = "make build"


### PR DESCRIPTION
# What

The `fetch` package causes a memory limit error when receiving a large response. In such cases, cloudflare recommends using `TransformStream`.

# Motivation

<!--
  Please describe the motivation for this change.
  If you have documentation (or a GitHub issue) related to this change, please give its URL.
-->

