### PR TITLE
build: update compat date, remove

### DIFF
--- a/_templates/cloudflare/worker-go/wrangler.toml
+++ b/_templates/cloudflare/worker-go/wrangler.toml
@@ -1,9 +1,6 @@
 name = "go-worker"
 main = "./build/worker.mjs"
-compatibility_date = "2022-11-19"
-compatibility_flags = [
-    "streams_enable_constructors"
-]
+compatibility_date = "2024-04-15"
 
 [build]
 command = "make build"


### PR DESCRIPTION
# What

Update the `compatibility_date` and remove the need for https://developers.cloudflare.com/workers/configuration/compatibility-dates/#streams-constructors as it is the default as of `2022-11-30`

# Motivation

Clearer for new users + ensures that new Workers features are adopted with the new compat date.

