### PR TITLE
add normal HTTP server listener for debugging purposes

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -1,3 +1,5 @@
+//go:build js && wasm
+
 package workers
 
 import (
@@ -85,7 +87,7 @@ func handleRequest(reqObj js.Value) (js.Value, error) {
 //go:wasmimport workers ready
 func ready()
 
-// Server serves http.Handler on Cloudflare Workers.
+// Server serves http.Handler on a JS runtime.
 // if the given handler is nil, http.DefaultServeMux will be used.
 func Serve(handler http.Handler) {
 	if handler == nil {

--- a/handler_without_js.go
+++ b/handler_without_js.go
@@ -1,0 +1,27 @@
+//go:build !js
+
+package workers
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+)
+
+// Server serves http.Handler as a normal HTTP server.
+// if the given handler is nil, http.DefaultServeMux will be used.
+// As a port number, PORT environment variable or default value (9900) is used.
+// This function is implemented for non-JS environments for debugging purposes.
+func Serve(handler http.Handler) {
+	if handler == nil {
+		handler = http.DefaultServeMux
+	}
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "9900"
+	}
+	addr := fmt.Sprintf(":%s", port)
+	fmt.Printf("listening on: http://localhost%s\n", addr)
+	fmt.Fprintln(os.Stderr, "warn: this server is currently running in non-JS mode. to enable JS-related features, please use the make command in the syumai/workers template.")
+	http.ListenAndServe(addr, handler)
+}


### PR DESCRIPTION
# What

* This PR adds normal HTTP server listener for debugging purposes.
* With this feature, the example below works using only the `go run` command without `GOOS` and `GOARCH`.

```go
package main

import (
	"fmt"
	"net/http"

	"github.com/syumai/workers"
)

func main() {
	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
		fmt.Fprint(w, "Hello, world!")
	})
	workers.Serve(handler)
}
```

# Motivation

* To make development easier for developers who are not familiar with JS/Wasm.
