### PR TITLE
add jsutil.MaybeInt wrapper; apply it to IncomingProperties.Asn

### DIFF
--- a/cloudflare/fetch/property.go
+++ b/cloudflare/fetch/property.go
@@ -184,7 +184,7 @@ func NewIncomingProperties(ctx context.Context) (*IncomingProperties, error) {
 		Latitude:                 jsutil.MaybeString(cf.Get("latitude")),
 		TLSCipher:                jsutil.MaybeString(cf.Get("tlsCipher")),
 		Continent:                jsutil.MaybeString(cf.Get("continent")),
-		Asn:                      cf.Get("asn").Int(),
+		Asn:                      jsutil.MaybeInt(cf.Get("asn")),
 		ClientAcceptEncoding:     jsutil.MaybeString(cf.Get("clientAcceptEncoding")),
 		Country:                  jsutil.MaybeString(cf.Get("country")),
 		TLSClientAuth:            NewIncomingTLSClientAuth(cf.Get("tlsClientAuth")),

--- a/internal/jsutil/jsutil.go
+++ b/internal/jsutil/jsutil.go
@@ -97,6 +97,14 @@ func MaybeString(v js.Value) string {
 	return v.String()
 }
 
+// MaybeInt returns int value of given JavaScript value or returns nil if the value is undefined.
+func MaybeInt(v js.Value) int {
+	if v.IsUndefined() {
+		return 0
+	}
+	return v.Int()
+}
+
 // MaybeDate returns time.Time value of given JavaScript Date value or returns nil if the value is undefined.
 func MaybeDate(v js.Value) (time.Time, error) {
 	if v.IsUndefined() {


### PR DESCRIPTION
# What

Adds a MaybeInt js.Value wrapper to jsutil.

# Motivation

Cloudflare sometimes provides a `cf` object with no `asn` key. This causes cloudflare/fetch.NewIncomingProperties() to panic. This is described in #119.

This change adds a js.Value wrapper for ints which first verifies if the Value is undefined.
