### PR TITLE
fixed panic on fetch returning empty response

### DIFF
--- a/cloudflare/fetch/bind.go
+++ b/cloudflare/fetch/bind.go
@@ -30,5 +30,5 @@ func fetch(namespace js.Value, req *http.Request, init *RequestInit) (*http.Resp
 		return nil, err
 	}
 
-	return jshttp.ToStreamResponse(jsRes)
+	return jshttp.ToResponse(jsRes)
 }

--- a/internal/jshttp/response.go
+++ b/internal/jshttp/response.go
@@ -30,17 +30,6 @@ func ToResponse(res js.Value) (*http.Response, error) {
 	return toResponse(res, body)
 }
 
-// ToStreamResponse pipes JavaScript sides Response to TransformStream and converts to *http.Response.
-//   - see: https://developers.cloudflare.com/workers/runtime-apis/streams/
-func ToStreamResponse(res js.Value) (*http.Response, error) {
-	ts := js.Global().Get("IdentityTransformStream").New()
-	readable := ts.Get("readable")
-	writable := ts.Get("writable")
-	res.Get("body").Call("pipeTo", writable)
-	body := jsutil.ConvertReadableStreamToReadCloser(readable)
-	return toResponse(res, body)
-}
-
 // ToJSResponse converts *http.Response to JavaScript sides Response class object.
 func ToJSResponse(res *http.Response) js.Value {
 	return newJSResponse(res.StatusCode, res.Header, res.Body, nil)


### PR DESCRIPTION
# What

* Stopped using `ToStreamResponse` in fetch func and replaced it to `ToResponse`.

# Motivation

* Current implementation of fetch panics when fetch result body is empty (No Content).
  - #122
* The piping logic to TransformStream is causing this issue.
  - Stream responses without TransformStream piping are already working since the following commit: https://github.com/syumai/workers/commit/bf3ab8ec410eed5ba7c8bb2da3aa41fd769adb20.
  - Therefore, I've stopped using TransformStream piping.

