### PR TITLE
Support HTTP Request and Cron Trigger in Single Worker

### DIFF
--- a/cloudflare/cron/scheduler.go
+++ b/cloudflare/cron/scheduler.go
@@ -55,3 +55,7 @@ func ScheduleTask(task Task) {
 	ready()
 	select {}
 }
+
+// ScheduleTaskNonBlock sets the Task to be executed but does not signal readiness or block
+// indefinitely. The non-blocking form is meant to be used in conjunction with [workers.Serve].
+func ScheduleTaskNonBlock(task Task) { scheduledTask = task }


### PR DESCRIPTION
Fixes #127

# What

Add a non-blocking version of `cron.ScheduleTask` so that it can be called before `workers.Serve`, allowing a single WASM binary to handle both cron triggers and HTTP requests

# Motivation

See #127