### PR TITLE
update wrangler.toml and wasm_exec_tinygo.js

### DIFF
--- a/_examples/basic-auth-proxy/wrangler.toml
+++ b/_examples/basic-auth-proxy/wrangler.toml
@@ -1,9 +1,7 @@
 name = "basic-auth-proxy"
 main = "./build/worker.mjs"
-compatibility_date = "2022-05-13"
-compatibility_flags = [
-    "streams_enable_constructors"
-]
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 
 [build]
 command = "make build"

--- a/_examples/cache/wrangler.toml
+++ b/_examples/cache/wrangler.toml
@@ -1,6 +1,7 @@
 name = "cache"
 main = "./build/worker.mjs"
-compatibility_date = "2023-02-24"
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 
 [build]
 command = "make build"

--- a/_examples/cron/wrangler.toml
+++ b/_examples/cron/wrangler.toml
@@ -1,6 +1,7 @@
 name = "scheduled"
 main = "./build/worker.mjs"
-compatibility_date = "2023-02-24"
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 workers_dev = false
 
 [triggers]

--- a/_examples/d1-blog-server/wrangler.toml
+++ b/_examples/d1-blog-server/wrangler.toml
@@ -1,6 +1,7 @@
 name = "d1-blog-server"
 main = "./build/worker.mjs"
-compatibility_date = "2024-04-15"
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 
 [build]
 command = "make build"

--- a/_examples/durable-object-counter/wrangler.toml
+++ b/_examples/durable-object-counter/wrangler.toml
@@ -1,9 +1,7 @@
 name = "durable-object-counter"
 main = "./worker.mjs"
-compatibility_date = "2022-05-13"
-compatibility_flags = [
-    "streams_enable_constructors"
-]
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 
 [build]
 command = "make build"

--- a/_examples/env/wrangler.toml
+++ b/_examples/env/wrangler.toml
@@ -1,9 +1,7 @@
 name = "env"
 main = "./build/worker.mjs"
-compatibility_date = "2022-05-13"
-compatibility_flags = [
-    "streams_enable_constructors"
-]
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 
 [build]
 command = "make build"

--- a/_examples/fetch-event/wrangler.toml
+++ b/_examples/fetch-event/wrangler.toml
@@ -1,6 +1,7 @@
 name = "fetch-event"
 main = "./build/worker.mjs"
-compatibility_date = "2023-02-24"
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 
 routes = [
     { pattern = "example.com/*", zone_name = "example.com" }

--- a/_examples/fetch/wrangler.toml
+++ b/_examples/fetch/wrangler.toml
@@ -1,6 +1,7 @@
 name = "fetch"
 main = "./build/worker.mjs"
-compatibility_date = "2023-02-24"
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 
 [build]
 command = "make build"

--- a/_examples/hello/wrangler.toml
+++ b/_examples/hello/wrangler.toml
@@ -1,9 +1,7 @@
 name = "hello"
 main = "./build/worker.mjs"
-compatibility_date = "2022-05-13"
-compatibility_flags = [
-    "streams_enable_constructors"
-]
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 
 [build]
 command = "make build"

--- a/_examples/incoming/wrangler.toml
+++ b/_examples/incoming/wrangler.toml
@@ -1,9 +1,7 @@
 name = "incoming"
 main = "./build/worker.mjs"
-compatibility_date = "2022-05-13"
-compatibility_flags = [
-    "streams_enable_constructors"
-]
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 
 [build]
 command = "make build"

--- a/_examples/kv-counter/wrangler.toml
+++ b/_examples/kv-counter/wrangler.toml
@@ -1,9 +1,7 @@
 name = "kv-counter"
 main = "./build/worker.mjs"
-compatibility_date = "2022-05-13"
-compatibility_flags = [
-    "streams_enable_constructors"
-]
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 
 [[kv_namespaces]]
 binding = "COUNTER"

--- a/_examples/multiple-handlers/wrangler.toml
+++ b/_examples/multiple-handlers/wrangler.toml
@@ -1,6 +1,7 @@
 name = "multiple-handlers"
 main = "./build/worker.mjs"
-compatibility_date = "2023-02-24"
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 workers_dev = false
 
 [triggers]

--- a/_examples/mysql-blog-server/wrangler.toml
+++ b/_examples/mysql-blog-server/wrangler.toml
@@ -1,6 +1,7 @@
 name = "mysql-blog-server"
 main = "./build/worker.mjs"
-compatibility_date = "2024-01-03"
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 
 [build]
 command = "make build"

--- a/_examples/pages-functions/wrangler.toml
+++ b/_examples/pages-functions/wrangler.toml
@@ -1,2 +1,3 @@
 name = "pages-functions"
-compatibility_date = "2023-04-30"
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]

--- a/_examples/queues/wrangler.toml
+++ b/_examples/queues/wrangler.toml
@@ -1,9 +1,7 @@
 name = "queues-producer"
 main = "./build/worker.mjs"
-compatibility_date = "2022-05-13"
-compatibility_flags = [
-    "streams_enable_constructors"
-]
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 
 [[queues.producers]]
 queue = "my-queue"

--- a/_examples/r2-image-server/wrangler.toml
+++ b/_examples/r2-image-server/wrangler.toml
@@ -1,9 +1,7 @@
 name = "r2-image-server"
 main = "./build/worker.mjs"
-compatibility_date = "2022-05-13"
-compatibility_flags = [
-    "streams_enable_constructors"
-]
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 
 [build]
 command = "make build"

--- a/_examples/r2-image-viewer/wrangler.toml
+++ b/_examples/r2-image-viewer/wrangler.toml
@@ -1,9 +1,7 @@
 name = "r2-image-viewer-tinygo"
 main = "./build/worker.mjs"
-compatibility_date = "2022-05-13"
-compatibility_flags = [
-    "streams_enable_constructors"
-]
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 
 [build]
 command = "make build"

--- a/_examples/service-bindings/wrangler.toml
+++ b/_examples/service-bindings/wrangler.toml
@@ -1,6 +1,7 @@
 name = "service-bindings"
 main = "./build/worker.mjs"
-compatibility_date = "2023-02-24"
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 services = [
     { binding = "hello", service = "hello" }
 ]

--- a/_examples/simple-json-server/wrangler.toml
+++ b/_examples/simple-json-server/wrangler.toml
@@ -1,9 +1,7 @@
 name = "simple-json-server"
 main = "./build/worker.mjs"
-compatibility_date = "2022-05-13"
-compatibility_flags = [
-    "streams_enable_constructors"
-]
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 
 [build]
 command = "make build"

--- a/_examples/sockets/wrangler.toml
+++ b/_examples/sockets/wrangler.toml
@@ -1,6 +1,7 @@
 name = "sockets"
 main = "./build/worker.mjs"
-compatibility_date = "2024-01-03"
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 
 [build]
 command = "make build"

--- a/_examples/stream-large-file/wrangler.toml
+++ b/_examples/stream-large-file/wrangler.toml
@@ -1,6 +1,7 @@
 name = "stream-large-file"
 main = "./build/worker.mjs"
-compatibility_date = "2023-12-01"
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 
 [build]
 command = "make build"

--- a/_templates/cloudflare/cron-go/README.md
+++ b/_templates/cloudflare/cron-go/README.md
@@ -18,7 +18,7 @@
 - Node.js
 - [wrangler](https://developers.cloudflare.com/workers/wrangler/)
   - Just run `npm install -g wrangler`
-- Go 1.21.0 or later
+- Go 1.23.3 or later
 
 ## Getting Started
 

--- a/_templates/cloudflare/cron-go/go.mod
+++ b/_templates/cloudflare/cron-go/go.mod
@@ -1,7 +1,3 @@
 module github.com/syumai/workers/_templates/cloudflare/cron-go
 
-go 1.21.3
-
-toolchain go1.22.4
-
-require github.com/syumai/workers v0.26.1
+go 1.23.3

--- a/_templates/cloudflare/cron-go/wrangler.toml
+++ b/_templates/cloudflare/cron-go/wrangler.toml
@@ -1,6 +1,7 @@
 name = "go-cron"
 main = "./build/worker.mjs"
-compatibility_date = "2023-02-24"
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 workers_dev = false
 
 [triggers]

--- a/_templates/cloudflare/cron-tinygo/README.md
+++ b/_templates/cloudflare/cron-tinygo/README.md
@@ -18,7 +18,7 @@
 - Node.js
 - [wrangler](https://developers.cloudflare.com/workers/wrangler/)
   - Just run `npm install -g wrangler`
-- Go 1.21.0 or later
+- tinygo 0.34.0 or later
 
 ## Getting Started
 

--- a/_templates/cloudflare/cron-tinygo/go.mod
+++ b/_templates/cloudflare/cron-tinygo/go.mod
@@ -1,7 +1,3 @@
 module github.com/syumai/workers/_templates/cloudflare/cron-tinygo
 
-go 1.21.3
-
-toolchain go1.22.4
-
-require github.com/syumai/workers v0.26.1
+go 1.23.3

--- a/_templates/cloudflare/cron-tinygo/wrangler.toml
+++ b/_templates/cloudflare/cron-tinygo/wrangler.toml
@@ -1,6 +1,7 @@
 name = "tinygo-cron"
 main = "./build/worker.mjs"
-compatibility_date = "2023-02-24"
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 workers_dev = false
 
 [triggers]

--- a/_templates/cloudflare/pages-tinygo/README.md
+++ b/_templates/cloudflare/pages-tinygo/README.md
@@ -12,7 +12,7 @@
 - Node.js
 - [wrangler](https://developers.cloudflare.com/workers/wrangler/)
   - just run `npm install -g wrangler`
-* tinygo 0.29.0 or later
+* tinygo 0.34.0 or later
 
 ## Getting Started
 

--- a/_templates/cloudflare/pages-tinygo/go.mod
+++ b/_templates/cloudflare/pages-tinygo/go.mod
@@ -1,5 +1,5 @@
 module github.com/syumai/workers/_examples/pages-tinygo
 
-go 1.21.1
+go 1.23.3
 
 require github.com/go-chi/chi/v5 v5.0.8

--- a/_templates/cloudflare/pages-tinygo/wrangler.toml
+++ b/_templates/cloudflare/pages-tinygo/wrangler.toml
@@ -1,5 +1,6 @@
 name = "pages-functions-tinygo"
-compatibility_date = "2024-04-15"
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 
 [build]
 command = "make build"

--- a/_templates/cloudflare/worker-go/README.md
+++ b/_templates/cloudflare/worker-go/README.md
@@ -17,7 +17,7 @@
 - Node.js
 - [wrangler](https://developers.cloudflare.com/workers/wrangler/)
   - just run `npm install -g wrangler`
-- Go 1.21.0 or later
+- Go 1.23.3 or later
 
 ## Getting Started
 

--- a/_templates/cloudflare/worker-go/go.mod
+++ b/_templates/cloudflare/worker-go/go.mod
@@ -1,3 +1,3 @@
 module github.com/syumai/workers/_templates/cloudflare/worker-go
 
-go 1.21.1
+go 1.23.3

--- a/_templates/cloudflare/worker-go/wrangler.toml
+++ b/_templates/cloudflare/worker-go/wrangler.toml
@@ -1,6 +1,7 @@
 name = "go-worker"
 main = "./build/worker.mjs"
-compatibility_date = "2024-04-15"
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 
 [build]
 command = "make build"

--- a/_templates/cloudflare/worker-tinygo/README.md
+++ b/_templates/cloudflare/worker-tinygo/README.md
@@ -12,7 +12,7 @@
 - Node.js
 - [wrangler](https://developers.cloudflare.com/workers/wrangler/)
   - just run `npm install -g wrangler`
-- tinygo 0.29.0 or later
+- tinygo 0.34.0 or later
 
 ## Getting Started
 

--- a/_templates/cloudflare/worker-tinygo/go.mod
+++ b/_templates/cloudflare/worker-tinygo/go.mod
@@ -1,3 +1,3 @@
 module github.com/syumai/workers/_templates/cloudflare/worker-tinygo
 
-go 1.21.1
+go 1.23.3

--- a/_templates/cloudflare/worker-tinygo/wrangler.toml
+++ b/_templates/cloudflare/worker-tinygo/wrangler.toml
@@ -1,6 +1,7 @@
 name = "tinygo-worker"
 main = "./build/worker.mjs"
-compatibility_date = "2024-04-15"
+compatibility_date = "2024-11-12"
+compatibility_flags = ["nodejs_compat"]
 
 [build]
 command = "make build"


### PR DESCRIPTION
# What

* updated wrangler.toml compatibility_date / flags and wasm_exec_tinygo.js ([v0.34.0](https://github.com/tinygo-org/tinygo/blob/v0.34.0/targets/wasm_exec.js))

