### PR TITLE
replace TinyGo with Go in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ func main() {
 ```
 
 For concrete examples, see `_examples` directory.
-Currently, all examples use tinygo instead of Go due to binary size issues.
 
 ## Quick Start
 
@@ -71,14 +70,14 @@ First, please install the following tools:
 * Node.js (and npm)
 * [wrangler](https://developers.cloudflare.com/workers/wrangler/)
   - You can install it by running `npm install -g wrangler`.
-* tinygo 0.29.0 or later
+* Go 1.21.3 or later
 * [gonew](https://pkg.go.dev/golang.org/x/tools/cmd/gonew)
   - You can install it by running `go install golang.org/x/tools/cmd/gonew@latest`
 
 After installation, please run the following commands.
 
 ```console
-gonew github.com/syumai/workers/_templates/cloudflare/worker-tinygo your.module/my-app # e.g. github.com/syumai/my-app
+gonew github.com/syumai/workers/_templates/cloudflare/worker-go your.module/my-app # e.g. github.com/syumai/my-app
 cd my-app
 go mod tidy
 make dev # start running dev server
@@ -97,9 +96,9 @@ To deploy a Worker, the following steps are required.
 * Build a Wasm binary.
 * Upload a Wasm binary with a JavaScript code to load and instantiate Wasm (for entry point).
 
-The [worker-tinygo template](https://github.com/syumai/workers/tree/main/_templates/cloudflare/worker-tinygo) contains all the required files, so I recommend using this template.
+The [worker-go template](https://github.com/syumai/workers/tree/main/_templates/cloudflare/worker-go) contains all the required files, so I recommend using this template.
 
-The [worker-go template](https://github.com/syumai/workers/tree/main/_templates/cloudflare/worker-go) (using regular Go, not tinygo) is also available, but it requires a paid plan of Cloudflare Workers (due to the large binary size).
+But Go (not TinyGo) with many dependencies may exceed the size limit of the Worker (3MB). In that case, you can use the [TinyGo template](https://github.com/syumai/workers/tree/main/_templates/cloudflare/worker-tinygo) instead.
 
 ### Where can I have discussions about contributions, or ask questions about how to use the library?
 


### PR DESCRIPTION
# What

* Cloudflare Workers now accepts 3MB worker, therefore I replaced TinyGo with Go in Quick Start guide.
  - https://developers.cloudflare.com/workers/platform/limits/

