### PR TITLE
rename ConsumeNonBlocking to ConsumeNonBlock

### DIFF
--- a/_examples/queues/README.md
+++ b/_examples/queues/README.md
@@ -25,7 +25,7 @@ make deploy # deploy worker
 NOTE: Wrangler does not support running multiple workers interacting with the same _local_ queue. Therefore, for the demostrational purposes,
 we use the same worker to both produce and consume messages from the queue. For a real-world scenario, please consider the differences
 between [queues.Consume](https://github.com/syumai/workers/blob/main/cloudflare/queues/consumer.go#L65) and 
-(queues.ConsumeNonBlocking)(https://github.com/syumai/workers/blob/main/cloudflare/queues/consumer.go#L75) functions.
+(queues.ConsumeNonBlock)(https://github.com/syumai/workers/blob/main/cloudflare/queues/consumer.go#L75) functions.
 
 1. Start the dev server.
 ```sh

--- a/_examples/queues/main.go
+++ b/_examples/queues/main.go
@@ -22,7 +22,7 @@ func handleErr(w http.ResponseWriter, msg string, err error) {
 func main() {
 	// start Qeueue consumer.
 	// If we would not have an HTTP handler in this worker, we would use queues.Consume instead
-	queues.ConsumeNonBlocking(consumeBatch)
+	queues.ConsumeNonBlock(consumeBatch)
 
 	// start HTTP server
 	http.HandleFunc("/", handleProduce)

--- a/cloudflare/queues/consumer.go
+++ b/cloudflare/queues/consumer.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Consumer is a function that received a batch of messages from Cloudflare Queues.
-// The function should be set using Consume or ConsumeNonBlocking.
+// The function should be set using Consume or ConsumeNonBlock.
 // A returned error will cause the batch to be retried (unless the batch or individual messages are acked).
 // NOTE: to do long-running message processing task within the Consumer, use cloudflare.WaitUntil, this will postpone the message
 // acknowledgment until the task is completed witout blocking the queue consumption.
@@ -61,17 +61,17 @@ func ready()
 // Consume sets the Consumer function to receive batches of messages from Cloudflare Queues
 // NOTE: This function will block the current goroutine and is intented to be used as long as the
 // only worker's purpose is to be the consumer of a Cloudflare Queue.
-// In case the worker has other purposes (e.g. handling HTTP requests), use ConsumeNonBlocking instead.
+// In case the worker has other purposes (e.g. handling HTTP requests), use ConsumeNonBlock instead.
 func Consume(f Consumer) {
 	consumer = f
 	ready()
 	select {}
 }
 
-// ConsumeNonBlocking sets the Consumer function to receive batches of messages from Cloudflare Queues.
+// ConsumeNonBlock sets the Consumer function to receive batches of messages from Cloudflare Queues.
 // This function is intented to be used when the worker has other purposes (e.g. handling HTTP requests).
 // The worker will not block receiving messages and will continue to execute other tasks.
-// ConsumeNonBlocking should be called before setting other blocking handlers (e.g. workers.Serve).
-func ConsumeNonBlocking(f Consumer) {
+// ConsumeNonBlock should be called before setting other blocking handlers (e.g. workers.Serve).
+func ConsumeNonBlock(f Consumer) {
 	consumer = f
 }


### PR DESCRIPTION
# What

Renamed ConsumeNonBlocking to ConsumeNonBlock.

# Motivation


To maintain consistency with `workers.ServeNonBlock` and similar cases.