### PR TITLE
Rename BatchMessage to MessageSendRequest

### DIFF
--- a/cloudflare/queues/batchmessage.go
+++ b/cloudflare/queues/batchmessage.go
@@ -6,45 +6,45 @@ import (
 	"github.com/syumai/workers/internal/jsutil"
 )
 
-// FIXME: rename to MessageSendRequest
+// MessageSendRequest is a wrapper type used for sending message batches.
 // see: https://developers.cloudflare.com/queues/configuration/javascript-apis/#messagesendrequest
-type BatchMessage struct {
+type MessageSendRequest struct {
 	body    js.Value
 	options *sendOptions
 }
 
-// NewTextBatchMessage creates a single text message to be batched before sending to a queue.
-func NewTextBatchMessage(content string, opts ...SendOption) *BatchMessage {
-	return newBatchMessage(js.ValueOf(content), contentTypeText, opts...)
+// NewTextMessageSendRequest creates a single text message to be batched before sending to a queue.
+func NewTextMessageSendRequest(content string, opts ...SendOption) *MessageSendRequest {
+	return newMessageSendRequest(js.ValueOf(content), contentTypeText, opts...)
 }
 
-// NewBytesBatchMessage creates a single byte array message to be batched before sending to a queue.
-func NewBytesBatchMessage(content []byte, opts ...SendOption) *BatchMessage {
-	return newBatchMessage(js.ValueOf(content), contentTypeBytes, opts...)
+// NewBytesMessageSendRequest creates a single byte array message to be batched before sending to a queue.
+func NewBytesMessageSendRequest(content []byte, opts ...SendOption) *MessageSendRequest {
+	return newMessageSendRequest(js.ValueOf(content), contentTypeBytes, opts...)
 }
 
-// NewJSONBatchMessage creates a single JSON message to be batched before sending to a queue.
-func NewJSONBatchMessage(content any, opts ...SendOption) *BatchMessage {
-	return newBatchMessage(js.ValueOf(content), contentTypeJSON, opts...)
+// NewJSONMessageSendRequest creates a single JSON message to be batched before sending to a queue.
+func NewJSONMessageSendRequest(content any, opts ...SendOption) *MessageSendRequest {
+	return newMessageSendRequest(js.ValueOf(content), contentTypeJSON, opts...)
 }
 
-// NewV8BatchMessage creates a single raw JS value message to be batched before sending to a queue.
-func NewV8BatchMessage(content js.Value, opts ...SendOption) *BatchMessage {
-	return newBatchMessage(content, contentTypeV8, opts...)
+// NewV8MessageSendRequest creates a single raw JS value message to be batched before sending to a queue.
+func NewV8MessageSendRequest(content js.Value, opts ...SendOption) *MessageSendRequest {
+	return newMessageSendRequest(content, contentTypeV8, opts...)
 }
 
-// newBatchMessage creates a single message to be batched before sending to a queue.
-func newBatchMessage(body js.Value, contentType contentType, opts ...SendOption) *BatchMessage {
+// newMessageSendRequest creates a single message to be batched before sending to a queue.
+func newMessageSendRequest(body js.Value, contentType contentType, opts ...SendOption) *MessageSendRequest {
 	options := sendOptions{
 		ContentType: contentType,
 	}
 	for _, opt := range opts {
 		opt(&options)
 	}
-	return &BatchMessage{body: body, options: &options}
+	return &MessageSendRequest{body: body, options: &options}
 }
 
-func (m *BatchMessage) toJS() js.Value {
+func (m *MessageSendRequest) toJS() js.Value {
 	obj := jsutil.NewObject()
 	obj.Set("body", m.body)
 	obj.Set("options", m.options.toJS())

--- a/cloudflare/queues/producer.go
+++ b/cloudflare/queues/producer.go
@@ -67,7 +67,7 @@ func (p *Producer) send(body js.Value, contentType contentType, opts ...SendOpti
 }
 
 // SendBatch sends multiple messages to a queue. This function allows setting options for each message.
-func (p *Producer) SendBatch(messages []*BatchMessage, opts ...BatchSendOption) error {
+func (p *Producer) SendBatch(messages []*MessageSendRequest, opts ...BatchSendOption) error {
 	var options batchSendOptions
 	for _, opt := range opts {
 		opt(&options)

--- a/cloudflare/queues/producer_test.go
+++ b/cloudflare/queues/producer_test.go
@@ -108,9 +108,9 @@ func TestSendBatch(t *testing.T) {
 		return nil
 	}
 
-	batch := []*BatchMessage{
-		NewJSONBatchMessage("hello"),
-		NewTextBatchMessage("world"),
+	batch := []*MessageSendRequest{
+		NewJSONMessageSendRequest("hello"),
+		NewTextMessageSendRequest("world"),
 	}
 
 	producer := validatingProducer(t, validation)
@@ -128,8 +128,8 @@ func TestSendBatch_Options(t *testing.T) {
 		return nil
 	}
 
-	batch := []*BatchMessage{
-		NewTextBatchMessage("hello"),
+	batch := []*MessageSendRequest{
+		NewTextMessageSendRequest("hello"),
 	}
 
 	producer := validatingProducer(t, validation)


### PR DESCRIPTION
# What

* The original name, BatchMessage, was inconsistent with Cloudflare's type definition.
* I changed its name to match Cloudflare's type definition.

# Motivation

* To reduce the difference in usage experience compared to Cloudflare's official library.

