### PR TITLE
remove version from workers-assets-gen command call

### DIFF
--- a/_templates/cloudflare/cron-go/Makefile
+++ b/_templates/cloudflare/cron-go/Makefile
@@ -4,7 +4,7 @@ dev:
 
 .PHONY: build
 build:
-	go run github.com/syumai/workers/cmd/workers-assets-gen@v0.28.1 -mode=go
+	go run github.com/syumai/workers/cmd/workers-assets-gen -mode=go
 	GOOS=js GOARCH=wasm go build -o ./build/app.wasm .
 
 .PHONY: deploy

--- a/_templates/cloudflare/cron-tinygo/Makefile
+++ b/_templates/cloudflare/cron-tinygo/Makefile
@@ -4,7 +4,7 @@ dev:
 
 .PHONY: build
 build:
-	go run github.com/syumai/workers/cmd/workers-assets-gen@v0.28.1
+	go run github.com/syumai/workers/cmd/workers-assets-gen
 	tinygo build -o ./build/app.wasm -target wasm -no-debug ./...
 
 .PHONY: deploy

--- a/_templates/cloudflare/pages-tinygo/Makefile
+++ b/_templates/cloudflare/pages-tinygo/Makefile
@@ -4,7 +4,7 @@ dev:
 
 .PHONY: build
 build:
-	go run github.com/syumai/workers/cmd/workers-assets-gen@v0.28.1
+	go run github.com/syumai/workers/cmd/workers-assets-gen
 	tinygo build -o ./build/app.wasm -target wasm -no-debug ./...
 
 .PHONY: deploy

--- a/_templates/cloudflare/worker-go/Makefile
+++ b/_templates/cloudflare/worker-go/Makefile
@@ -4,7 +4,7 @@ dev:
 
 .PHONY: build
 build:
-	go run github.com/syumai/workers/cmd/workers-assets-gen@v0.28.1 -mode=go
+	go run github.com/syumai/workers/cmd/workers-assets-gen -mode=go
 	GOOS=js GOARCH=wasm go build -o ./build/app.wasm .
 
 .PHONY: deploy

--- a/_templates/cloudflare/worker-tinygo/Makefile
+++ b/_templates/cloudflare/worker-tinygo/Makefile
@@ -4,7 +4,7 @@ dev:
 
 .PHONY: build
 build:
-	go run github.com/syumai/workers/cmd/workers-assets-gen@v0.28.1
+	go run github.com/syumai/workers/cmd/workers-assets-gen
 	tinygo build -o ./build/app.wasm -target wasm -no-debug ./...
 
 .PHONY: deploy


### PR DESCRIPTION
# What

* remove version from `workers-assets-gen` command calls in templates.

# Motivation

* It was unnecessary.
  - `workers-assets-gen` command should be same version with `syumai/workers` module in `go.mod`.
  - `go run` selects module version from `go.mod`.
    - [docs](https://go.dev/ref/mod#:~:text=In%20module%2Daware%20mode%2C%20the%20go%20command%20uses%20go.mod%20files%20to%20find%20versioned%20dependencies%2C%20and%20it%20typically%20loads%20packages%20out%20of%20the%20module%20cache%2C%20downloading%20modules%20if%20they%20are%20missing.)