### PR TITLE
split runtime param of workers-assets-gen command

### DIFF
--- a/cmd/workers-assets-gen/assets/common/shim.mjs
+++ b/cmd/workers-assets-gen/assets/common/shim.mjs
@@ -40,13 +40,13 @@ async function run(ctx) {
 
 export async function fetch(req, env, ctx) {
   const binding = {};
-  await run(createRuntimeContext(env, ctx, binding));
+  await run(createRuntimeContext({ env, ctx, binding }));
   return binding.handleRequest(req);
 }
 
 export async function scheduled(event, env, ctx) {
   const binding = {};
-  await run(createRuntimeContext(env, ctx, binding));
+  await run(createRuntimeContext({ env, ctx, binding }));
   return binding.runScheduler(event);
 }
 
@@ -54,12 +54,12 @@ export async function scheduled(event, env, ctx) {
 export async function onRequest(ctx) {
   const binding = {};
   const { request, env } = ctx;
-  await run(createRuntimeContext(env, ctx, binding));
+  await run(createRuntimeContext({ env, ctx, binding }));
   return binding.handleRequest(request);
 }
 
 export async function queue(batch, env, ctx) {
   const binding = {};
-  await run(createRuntimeContext(env, ctx, binding));
+  await run(createRuntimeContext({ env, ctx, binding }));
   return binding.handleQueueMessageBatch(batch);
 }

--- a/cmd/workers-assets-gen/assets/common/shim.mjs
+++ b/cmd/workers-assets-gen/assets/common/shim.mjs
@@ -1,5 +1,5 @@
 import "./wasm_exec.js";
-import { connect } from 'cloudflare:sockets';
+import { createRuntimeContext } from "./runtime.mjs";
 
 let mod;
 
@@ -8,12 +8,12 @@ globalThis.tryCatch = (fn) => {
     return {
       result: fn(),
     };
-  } catch(e) {
+  } catch (e) {
     return {
       error: e,
     };
   }
-}
+};
 
 export function init(m) {
   mod = m;
@@ -29,20 +29,13 @@ async function run(ctx) {
   const instance = new WebAssembly.Instance(mod, {
     ...go.importObject,
     workers: {
-      ready: () => { ready() }
+      ready: () => {
+        ready();
+      },
     },
   });
   go.run(instance, ctx);
   await readyPromise;
-}
-
-function createRuntimeContext(env, ctx, binding) {
-  return {
-    env,
-    ctx,
-    connect,
-    binding,
-  };
 }
 
 export async function fetch(req, env, ctx) {

--- a/cmd/workers-assets-gen/assets/runtime/cloudflare.mjs
+++ b/cmd/workers-assets-gen/assets/runtime/cloudflare.mjs
@@ -1,0 +1,10 @@
+import { connect } from "cloudflare:sockets";
+
+export function createRuntimeContext(env, ctx, binding) {
+  return {
+    env,
+    ctx,
+    connect,
+    binding,
+  };
+}

--- a/cmd/workers-assets-gen/assets/runtime/cloudflare.mjs
+++ b/cmd/workers-assets-gen/assets/runtime/cloudflare.mjs
@@ -1,6 +1,6 @@
 import { connect } from "cloudflare:sockets";
 
-export function createRuntimeContext(env, ctx, binding) {
+export function createRuntimeContext({ env, ctx, binding }) {
   return {
     env,
     ctx,

--- a/cmd/workers-assets-gen/runtime.go
+++ b/cmd/workers-assets-gen/runtime.go
@@ -1,0 +1,19 @@
+package main
+
+type Runtime string
+
+const (
+	RuntimeCloudflare Runtime = "cloudflare"
+)
+
+func (r Runtime) IsValid() bool {
+	switch r {
+	case RuntimeCloudflare:
+		return true
+	}
+	return false
+}
+
+func (r Runtime) AssetFileName() string {
+	return string(r) + ".mjs"
+}


### PR DESCRIPTION
# What

* split `import { connect } from "cloudflare:sockets";` to `assets/runtime/cloudflare.mjs`.

# Motivation

* To support other runtimes.

