### PR TITLE
fix bug of FixedLengthTransformStream

### DIFF
--- a/_examples/hello/Makefile
+++ b/_examples/hello/Makefile
@@ -4,8 +4,8 @@ dev:
 
 .PHONY: build
 build:
-	go run ../../cmd/workers-assets-gen
-	tinygo build -o ./build/app.wasm -target wasm -no-debug ./...
+	go run ../../cmd/workers-assets-gen -mode=go
+	GOOS=js GOARCH=wasm go build -o ./build/app.wasm .
 
 .PHONY: deploy
 deploy:

--- a/_examples/hello/README.md
+++ b/_examples/hello/README.md
@@ -15,7 +15,7 @@
 This project requires these tools to be installed globally.
 
 * wrangler
-* tinygo
+* Go
 
 ### Commands
 

--- a/internal/jsutil/jsutil.go
+++ b/internal/jsutil/jsutil.go
@@ -19,9 +19,12 @@ var (
 	Uint8ClampedArrayClass = js.Global().Get("Uint8ClampedArray")
 	ErrorClass             = js.Global().Get("Error")
 	ReadableStreamClass    = js.Global().Get("ReadableStream")
-	FixedLengthStreamClass = js.Global().Get("FixedLengthStream")
 	DateClass              = js.Global().Get("Date")
 	Null                   = js.ValueOf(nil)
+	// MaybeFixedLengthStreamClass is a class for FixedLengthStream.
+	// * This class is only available in Cloudflare Workers.
+	// * If this class is not available, the value will be undefined.
+	MaybeFixedLengthStreamClass = js.Global().Get("FixedLengthStream")
 )
 
 func NewObject() js.Value {


### PR DESCRIPTION
# What


* Add an existence check for FixedLengthStream.
  - Because the browser environment (added recently) doesn't have it.
* Add a `ready` check to write calls to the WritableStream of FixedLengthStream.
  - See: https://developer.mozilla.org/en-US/docs/Web/API/WritableStream#backpressure

# Motivation

To fix https://github.com/syumai/workers/issues/101#issuecomment-2718681263