### PR TITLE
return empty ReadCloser for nil request body

### DIFF
--- a/internal/jshttp/request.go
+++ b/internal/jshttp/request.go
@@ -1,6 +1,7 @@
 package jshttp
 
 import (
+	"bytes"
 	"io"
 	"net/http"
 	"net/url"
@@ -15,7 +16,7 @@ import (
 //   - ReadableStream: https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream
 func ToBody(streamOrNull js.Value) io.ReadCloser {
 	if streamOrNull.IsNull() {
-		return nil
+		return io.NopCloser(bytes.NewReader([]byte{}))
 	}
 	return jsutil.ConvertReadableStreamToReadCloser(streamOrNull)
 }


### PR DESCRIPTION
# What

* Changed code to return an empty ReadCloser when request body is nil.

# Motivation

* Without this change, if a handler attempts to access Request.Body when it's nil, the application would panic. This fix prevents the crash and provides a proper empty reader instead.