### PR TITLE
Rewrite examples tinygo to go

### DIFF
--- a/_examples/basic-auth-proxy/Makefile
+++ b/_examples/basic-auth-proxy/Makefile
@@ -4,8 +4,8 @@ dev:
 
 .PHONY: build
 build:
-	go run ../../cmd/workers-assets-gen
-	tinygo build -o ./build/app.wasm -target wasm -no-debug ./...
+	go run ../../cmd/workers-assets-gen -mode=go
+	GOOS=js GOARCH=wasm go build -o ./build/app.wasm .
 
 .PHONY: deploy
 deploy:

--- a/_examples/basic-auth-proxy/README.md
+++ b/_examples/basic-auth-proxy/README.md
@@ -17,12 +17,12 @@
 This project requires these tools to be installed globally.
 
 * wrangler
-* tinygo
+* Go 1.24.0 or later
 
 ### Commands
 
 ```
 make dev     # run dev server
 make build   # build Go Wasm binary
-make deploy # deploy worker
+make deploy  # deploy worker
 ```

--- a/_examples/cache/Makefile
+++ b/_examples/cache/Makefile
@@ -4,9 +4,8 @@ dev:
 
 .PHONY: build
 build:
-	go run ../../cmd/workers-assets-gen
-	#tinygo build -o ./build/app.wasm -target wasm -no-debug ./...
-	tinygo build -o ./build/app.wasm -target wasm -no-debug ./...
+	go run ../../cmd/workers-assets-gen -mode=go
+	GOOS=js GOARCH=wasm go build -o ./build/app.wasm .
 
 .PHONY: deploy
 deploy:

--- a/_examples/cache/README.md
+++ b/_examples/cache/README.md
@@ -9,12 +9,12 @@ The Cache API allows fine grained control of reading and writing from the Cloudf
 This project requires these tools to be installed globally.
 
 * wrangler
-* tinygo
+* Go 1.24.0 or later
 
 #### Commands
 
 ```
 make dev     # run dev server
 make build   # build Go Wasm binary
-make deploy # deploy worker
+make deploy  # deploy worker
 ```

--- a/_examples/cache/main.go
+++ b/_examples/cache/main.go
@@ -12,6 +12,10 @@ import (
 	"github.com/syumai/workers/cloudflare/cache"
 )
 
+func canHaveBody(method string) bool {
+	return method != "GET" && method != "HEAD" && method != ""
+}
+
 type responseWriter struct {
 	http.ResponseWriter
 	StatusCode int
@@ -64,7 +68,11 @@ func handler(w http.ResponseWriter, req *http.Request) {
 
 	// Create cache
 	cloudflare.WaitUntil(func() {
-		err := c.Put(req, rw.ToHTTPResponse())
+		r := rw.ToHTTPResponse()
+		if !canHaveBody(req.Method) {
+			r.Body = nil
+		}
+		err := c.Put(req, r)
 		if err != nil {
 			fmt.Println(err)
 		}

--- a/_examples/cache/main.go
+++ b/_examples/cache/main.go
@@ -44,6 +44,10 @@ func handler(w http.ResponseWriter, req *http.Request) {
 	rw := responseWriter{ResponseWriter: w}
 	c := cache.New()
 
+	if !canHaveBody(req.Method) {
+		req.Body = nil
+	}
+
 	// Find cache
 	res, _ := c.Match(req, nil)
 	if res != nil {
@@ -68,11 +72,7 @@ func handler(w http.ResponseWriter, req *http.Request) {
 
 	// Create cache
 	cloudflare.WaitUntil(func() {
-		r := rw.ToHTTPResponse()
-		if !canHaveBody(req.Method) {
-			r.Body = nil
-		}
-		err := c.Put(req, r)
+		err := c.Put(req, rw.ToHTTPResponse())
 		if err != nil {
 			fmt.Println(err)
 		}

--- a/_examples/cron/Makefile
+++ b/_examples/cron/Makefile
@@ -4,8 +4,8 @@ dev:
 
 .PHONY: build
 build:
-	go run ../../cmd/workers-assets-gen
-	tinygo build -o ./build/app.wasm -target wasm -no-debug ./...
+	go run ../../cmd/workers-assets-gen -mode=go
+	GOOS=js GOARCH=wasm go build -o ./build/app.wasm .
 
 .PHONY: deploy
 deploy:

--- a/_examples/cron/README.md
+++ b/_examples/cron/README.md
@@ -9,14 +9,14 @@
 This project requires these tools to be installed globally.
 
 * wrangler
-* tinygo
+* Go 1.24.0 or later
 
 ### Commands
 
 ```
 make dev     # run dev server
 make build   # build Go Wasm binary
-make deploy # deploy worker
+make deploy  # deploy worker
 ```
 
 #### Testing cron schedule

--- a/_examples/d1-blog-server/Makefile
+++ b/_examples/d1-blog-server/Makefile
@@ -4,16 +4,20 @@ dev:
 
 .PHONY: build
 build:
-	go run ../../cmd/workers-assets-gen
-	tinygo build -o ./build/app.wasm -target wasm -no-debug ./main.go
+	go run ../../cmd/workers-assets-gen -mode=go
+	GOOS=js GOARCH=wasm go build -o ./build/app.wasm .
 
 .PHONY: deploy
 deploy:
 	wrangler deploy
 
+.PHONY: create-db
+create-db:
+	wrangler d1 create d1-blog-server
+
 .PHONY: init-db
 init-db:
-	wrangler d1 execute d1-blog-server --file=./schema.sql
+	wrangler d1 execute d1-blog-server --remote --file=./schema.sql
 
 .PHONY: init-db-local
 init-db-local:

--- a/_examples/d1-blog-server/README.md
+++ b/_examples/d1-blog-server/README.md
@@ -59,7 +59,7 @@ $ curl 'https://d1-blog-server.syumai.workers.dev/articles'
 This project requires these tools to be installed globally.
 
 * wrangler
-* tinygo
+* Go 1.24.0 or later
 
 ### Commands
 
@@ -70,8 +70,10 @@ make dev           # run dev server
 make build         # build Go Wasm binary
 
 # production
-make init-db # initialize production DB (remove all rows)
-make deploy # deploy worker
+make create-db # create production DB
+# copy binding to wrangler.toml
+make init-db   # initialize production DB (remove all rows)
+make deploy    # deploy worker
 ```
 
-* Notice: This example uses raw SQL commands to initialize the DB for simplicity, but in general you should use `wrangler d1 migraions` for your application.
+* Notice: This example uses raw SQL commands to initialize the DB for simplicity, but in general you should use `wrangler d1 migrations` for your application.

--- a/_examples/d1-blog-server/main.go
+++ b/_examples/d1-blog-server/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	db, err := sql.Open("d1", "BlogDB")
+	db, err := sql.Open("d1", "DB")
 	if err != nil {
 		log.Fatalf("error opening DB: %s", err.Error())
 	}

--- a/_examples/d1-blog-server/wrangler.toml
+++ b/_examples/d1-blog-server/wrangler.toml
@@ -4,9 +4,3 @@ compatibility_date = "2024-04-15"
 
 [build]
 command = "make build"
-
-[[ d1_databases ]]
-binding = "BlogDB"
-database_name = "d1-blog-server"
-database_id = "c6d5e4c0-3134-42fa-834c-812b24fea3cf"
-preview_database_id = "BlogDB"

--- a/_examples/durable-object-counter/Makefile
+++ b/_examples/durable-object-counter/Makefile
@@ -4,8 +4,8 @@ dev:
 
 .PHONY: build
 build:
-	go run ../../cmd/workers-assets-gen
-	tinygo build -o ./build/app.wasm -target wasm -no-debug ./...
+	go run ../../cmd/workers-assets-gen -mode=go
+	GOOS=js GOARCH=wasm go build -o ./build/app.wasm ./...
 
 .PHONY: deploy
 deploy:

--- a/_examples/durable-object-counter/README.md
+++ b/_examples/durable-object-counter/README.md
@@ -21,14 +21,14 @@ After `make deploy` the trigger is `http://durable-object-counter.YOUR-DOMAIN.wo
 This project requires these tools to be installed globally.
 
 * wrangler
-* tinygo
+* Go 1.24.0 or later
 
 ### Commands
 
 ```
 make dev     # run dev server
 make build   # build Go Wasm binary
-make deploy # deploy worker
+make deploy  # deploy worker
 ```
 
 ## Author

--- a/_examples/durable-object-counter/main.go
+++ b/_examples/durable-object-counter/main.go
@@ -12,6 +12,10 @@ func main() {
 	workers.Serve(&MyHandler{})
 }
 
+func canHaveBody(method string) bool {
+	return method != "GET" && method != "HEAD" && method != ""
+}
+
 type MyHandler struct{}
 
 func (_ *MyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
@@ -24,6 +28,10 @@ func (_ *MyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	obj, err := COUNTER.Get(id)
 	if err != nil {
 		panic(err)
+	}
+
+	if !canHaveBody(req.Method) {
+		req.Body = nil
 	}
 
 	res, err := obj.Fetch(req)

--- a/_examples/durable-object-counter/wrangler.toml
+++ b/_examples/durable-object-counter/wrangler.toml
@@ -13,4 +13,4 @@ bindings = [{name = "COUNTER", class_name = "Counter"}]
 
 [[migrations]]
 tag = "v1" # Should be unique for each entry
-new_classes = ["Counter"]
+new_sqlite_classes = ["Counter"]

--- a/_examples/env/Makefile
+++ b/_examples/env/Makefile
@@ -4,8 +4,8 @@ dev:
 
 .PHONY: build
 build:
-	go run ../../cmd/workers-assets-gen
-	tinygo build -o ./build/app.wasm -target wasm -no-debug ./...
+	go run ../../cmd/workers-assets-gen -mode=go
+	GOOS=js GOARCH=wasm go build -o ./build/app.wasm ./...
 
 .PHONY: deploy
 deploy:

--- a/_examples/env/README.md
+++ b/_examples/env/README.md
@@ -13,12 +13,12 @@
 This project requires these tools to be installed globally.
 
 * wrangler
-* tinygo
+* Go 1.24.0 or later
 
 ### Commands
 
 ```
 make dev     # run dev server
 make build   # build Go Wasm binary
-make deploy # deploy worker
+make deploy  # deploy worker
 ```

--- a/_examples/fetch-event/Makefile
+++ b/_examples/fetch-event/Makefile
@@ -4,8 +4,8 @@ dev:
 
 .PHONY: build
 build:
-	go run ../../cmd/workers-assets-gen
-	tinygo build -o ./build/app.wasm -target wasm -no-debug ./...
+	go run ../../cmd/workers-assets-gen -mode=go
+	GOOS=js GOARCH=wasm go build -o ./build/app.wasm ./...
 
 .PHONY: deploy
 deploy:

--- a/_examples/fetch-event/README.md
+++ b/_examples/fetch-event/README.md
@@ -37,12 +37,12 @@ The workers is executed if the URL matches `sub.example.com/*`.
 This project requires these tools to be installed globally.
 
 * wrangler
-* tinygo
+* Go 1.24.0 or later
 
 #### Commands
 
 ```
 make dev     # run dev server
 make build   # build Go Wasm binary
-make deploy # deploy worker
+make deploy  # deploy worker
 ```

--- a/_examples/fetch-event/wrangler.toml
+++ b/_examples/fetch-event/wrangler.toml
@@ -2,9 +2,10 @@ name = "fetch-event"
 main = "./build/worker.mjs"
 compatibility_date = "2023-02-24"
 
-routes = [
-    { pattern = "example.com/*", zone_name = "example.com" }
-]
+# setup route and uncomment
+# routes = [
+#     { pattern = "example.com/*", zone_name = "example.com" }
+# ]
 
 [build]
 command = "make build"

--- a/_examples/fetch/Makefile
+++ b/_examples/fetch/Makefile
@@ -4,8 +4,8 @@ dev:
 
 .PHONY: build
 build:
-	go run ../../cmd/workers-assets-gen
-	tinygo build -o ./build/app.wasm -target wasm -no-debug ./...
+	go run ../../cmd/workers-assets-gen -mode=go
+	GOOS=js GOARCH=wasm go build -o ./build/app.wasm ./...
 
 .PHONY: deploy
 deploy:

--- a/_examples/fetch/README.md
+++ b/_examples/fetch/README.md
@@ -10,12 +10,11 @@
 This project requires these tools to be installed globally.
 
 * wrangler
-* tinygo
-
+* Go 1.24.0 or later
 ### Commands
 
 ```
 make dev     # run dev server
 make build   # build Go Wasm binary
-make deploy # deploy worker
+make deploy  # deploy worker
 ```

--- a/_examples/incoming/Makefile
+++ b/_examples/incoming/Makefile
@@ -4,8 +4,8 @@ dev:
 
 .PHONY: build
 build:
-	go run ../../cmd/workers-assets-gen
-	tinygo build -o ./build/app.wasm -target wasm -no-debug ./...
+	go run ../../cmd/workers-assets-gen -mode=go
+	GOOS=js GOARCH=wasm go build -o ./build/app.wasm ./...
 
 .PHONY: deploy
 deploy:

--- a/_examples/kv-counter/Makefile
+++ b/_examples/kv-counter/Makefile
@@ -4,8 +4,12 @@ dev:
 
 .PHONY: build
 build:
-	go run ../../cmd/workers-assets-gen
-	tinygo build -o ./build/app.wasm -target wasm -no-debug ./...
+	go run ../../cmd/workers-assets-gen -mode=go
+	GOOS=js GOARCH=wasm go build -o ./build/app.wasm ./...
+
+.PHONY: create-kv-namespace
+create-kv-namespace:
+	wrangler kv namespace create COUNTER
 
 .PHONY: deploy
 deploy:

--- a/_examples/kv-counter/README.md
+++ b/_examples/kv-counter/README.md
@@ -13,12 +13,13 @@
 This project requires these tools to be installed globally.
 
 * wrangler
-* tinygo
+* Go 1.24.0 or later
 
 ### Commands
 
 ```
-make dev     # run dev server
-make build   # build Go Wasm binary
-make deploy # deploy worker
+make dev                  # run dev server
+make build                # build Go Wasm binary
+make create-kv-namespace  # creates a kv namespace - add binding to wrangler.toml before deploy
+make deploy               # deploy worker
 ```

--- a/_examples/kv-counter/wrangler.toml
+++ b/_examples/kv-counter/wrangler.toml
@@ -5,10 +5,5 @@ compatibility_flags = [
     "streams_enable_constructors"
 ]
 
-[[kv_namespaces]]
-binding = "COUNTER"
-id = "fe0ef36853f04fe986c1ade5271ea6a4"
-preview_id = "916f05d37f4741e0a19aa3d0bd4d282e"
-
 [build]
 command = "make build"

--- a/_examples/multiple-handlers/Makefile
+++ b/_examples/multiple-handlers/Makefile
@@ -4,8 +4,8 @@ dev:
 
 .PHONY: build
 build:
-	go run ../../cmd/workers-assets-gen
-	tinygo build -o ./build/app.wasm -target wasm -no-debug ./...
+	go run ../../cmd/workers-assets-gen -mode=go
+	GOOS=js GOARCH=wasm go build -o ./build/app.wasm ./...
 
 .PHONY: deploy
 deploy:

--- a/_examples/multiple-handlers/README.md
+++ b/_examples/multiple-handlers/README.md
@@ -9,14 +9,14 @@
 This project requires these tools to be installed globally.
 
 * wrangler
-* tinygo
+* Go 1.24.0 or later
 
 ### Commands
 
 ```
 make dev     # run dev server
 make build   # build Go Wasm binary
-make deploy # deploy worker
+make deploy  # deploy worker
 ```
 
 #### Testing cron schedule

--- a/_examples/multiple-handlers/wrangler.toml
+++ b/_examples/multiple-handlers/wrangler.toml
@@ -1,7 +1,6 @@
 name = "multiple-handlers"
 main = "./build/worker.mjs"
 compatibility_date = "2023-02-24"
-workers_dev = false
 
 [triggers]
 crons = ["* * * * *"]

--- a/_examples/pages-functions/Makefile
+++ b/_examples/pages-functions/Makefile
@@ -4,8 +4,8 @@ dev:
 
 .PHONY: build
 build:
-	go run ../../cmd/workers-assets-gen
-	tinygo build -o ./build/app.wasm -target wasm -no-debug ./...
+	go run ../../cmd/workers-assets-gen -mode=go
+	GOOS=js GOARCH=wasm go build -o ./build/app.wasm ./...
 
 .PHONY: deploy
 deploy:

--- a/_examples/pages-functions/README.md
+++ b/_examples/pages-functions/README.md
@@ -13,12 +13,12 @@
 This project requires these tools to be installed globally.
 
 * wrangler
-* tinygo
+* Go 1.24.0 or later
 
 ### Commands
 
 ```
 make build   # build Go Wasm binary
 make dev     # run dev server
-make deploy # deploy worker
+make deploy  # deploy worker
 ```

--- a/_examples/pages-functions/wrangler.toml
+++ b/_examples/pages-functions/wrangler.toml
@@ -1,2 +1,6 @@
 name = "pages-functions"
+main = "./build/worker.mjs"
 compatibility_date = "2023-04-30"
+
+[build]
+command = "make build"

--- a/_examples/queues/Makefile
+++ b/_examples/queues/Makefile
@@ -4,8 +4,12 @@ dev:
 
 .PHONY: build
 build:
-	go run ../../cmd/workers-assets-gen
-	tinygo build -o ./build/app.wasm -target wasm -no-debug ./...
+	go run ../../cmd/workers-assets-gen -mode=go
+	GOOS=js GOARCH=wasm go build -o ./build/app.wasm ./...
+
+.PHONY: create-queue
+create-queue:
+	wrangler queues create my-queue
 
 .PHONY: deploy
 deploy:

--- a/_examples/queues/README.md
+++ b/_examples/queues/README.md
@@ -9,14 +9,15 @@ An example of using Cloudflare Workers that interact with [Cloudflare Queues](ht
 This project requires these tools to be installed globally.
 
 * wrangler
-* tinygo
+* Go 1.24.0 or later
 
 ### Supported commands
 
 ```
-make dev     # run dev server
-make build   # build Go Wasm binary
-make deploy # deploy worker
+make dev          # run dev server
+make build        # build Go Wasm binary
+make create-queue # creates the queue
+make deploy       # deploy worker
 ```
 
 ### Interacting with the local queue

--- a/_examples/r2-image-server/Makefile
+++ b/_examples/r2-image-server/Makefile
@@ -4,8 +4,12 @@ dev:
 
 .PHONY: build
 build:
-	go run ../../cmd/workers-assets-gen
-	tinygo build -o ./build/app.wasm -target wasm -no-debug ./...
+	go run ../../cmd/workers-assets-gen -mode=go
+	GOOS=js GOARCH=wasm go build -o ./build/app.wasm .
+
+.PHONY: create-bucket
+create-bucket:
+	wrangler r2 bucket create r2-image-viewer
 
 .PHONY: deploy
 deploy:

--- a/_examples/r2-image-server/README.md
+++ b/_examples/r2-image-server/README.md
@@ -26,12 +26,13 @@
 This project requires these tools to be installed globally.
 
 * wrangler
-* tinygo
+* Go 1.24.0 or later
 
 ### Commands
 
 ```
-make dev     # run dev server
-make build   # build Go Wasm binary
-make deploy # deploy worker
+make dev           # run dev server
+make build         # build Go Wasm binary
+make create-bucket # create r2 bucket
+make deploy        # deploy worker
 ```

--- a/_examples/r2-image-viewer/Makefile
+++ b/_examples/r2-image-viewer/Makefile
@@ -4,8 +4,12 @@ dev:
 
 .PHONY: build
 build:
-	go run ../../cmd/workers-assets-gen
-	tinygo build -o ./build/app.wasm -target wasm -no-debug ./...
+	go run ../../cmd/workers-assets-gen -mode=go
+	GOOS=js GOARCH=wasm go build -o ./build/app.wasm ./...
+
+.PHONY: create-bucket
+create-bucket:
+	wrangler r2 bucket create r2-image-viewer
 
 .PHONY: deploy
 deploy:

--- a/_examples/r2-image-viewer/README.md
+++ b/_examples/r2-image-viewer/README.md
@@ -1,7 +1,7 @@
 # r2-image-viewer-tinygo
 
 * An example server which returns image from Cloudflare R2.
-* This server is implemented in Go and compiled with tinygo.
+* This server is implemented in Go.
 
 ## Example
 
@@ -14,12 +14,13 @@
 This project requires these tools to be installed globally.
 
 * wrangler
-* tinygo
+* Go 1.24.0 or later
 
 ### Commands
 
 ```
-make dev     # run dev server
-make build   # build Go Wasm binary
-make deploy # deploy worker
+make dev           # run dev server
+make build         # build Go Wasm binary
+make create-bucket # create r2 bucket
+make deploy        # deploy worker
 ```

--- a/_examples/service-bindings/Makefile
+++ b/_examples/service-bindings/Makefile
@@ -4,8 +4,8 @@ dev:
 
 .PHONY: build
 build:
-	go run ../../cmd/workers-assets-gen
-	tinygo build -o ./build/app.wasm -target wasm -no-debug ./...
+	go run ../../cmd/workers-assets-gen -mode=go
+	GOOS=js GOARCH=wasm go build -o ./build/app.wasm ./...
 
 .PHONY: deploy
 deploy:

--- a/_examples/service-bindings/README.md
+++ b/_examples/service-bindings/README.md
@@ -10,7 +10,7 @@
 This project requires these tools to be installed globally.
 
 * wrangler
-* tinygo
+* Go 1.24.0 or later
 
 ### Deploy Steps
 
@@ -24,7 +24,7 @@ This project requires these tools to be installed globally.
 3. Deploy this example.
     ```
     make build   # build Go Wasm binary
-    make deploy # deploy worker
+    make deploy  # deploy worker
     ```
 
 ## Documents

--- a/_examples/simple-json-server/Makefile
+++ b/_examples/simple-json-server/Makefile
@@ -4,8 +4,8 @@ dev:
 
 .PHONY: build
 build:
-	go run ../../cmd/workers-assets-gen
-	tinygo build -o ./build/app.wasm -target wasm -no-debug ./main.go
+	go run ../../cmd/workers-assets-gen -mode=go
+	GOOS=js GOARCH=wasm go build -o ./build/app.wasm ./...
 
 .PHONY: deploy
 deploy:

--- a/_examples/simple-json-server/README.md
+++ b/_examples/simple-json-server/README.md
@@ -31,12 +31,12 @@ curl --location --request POST 'https://simple-json-server.syumai.workers.dev/he
 This project requires these tools to be installed globally.
 
 * wrangler
-* tinygo
+* Go 1.24.0 or later
 
 ### Commands
 
 ```
 make dev     # run dev server
 make build   # build Go Wasm binary
-make deploy # deploy worker
+make deploy  # deploy worker
 ```

--- a/_examples/stream-large-file/Makefile
+++ b/_examples/stream-large-file/Makefile
@@ -4,8 +4,8 @@ dev:
 
 .PHONY: build
 build:
-	go run ../../cmd/workers-assets-gen
-	tinygo build -o ./build/app.wasm -target wasm -no-debug ./...
+	go run ../../cmd/workers-assets-gen -mode=go
+	GOOS=js GOARCH=wasm go build -o ./build/app.wasm ./...
 
 .PHONY: deploy
 deploy:

--- a/_examples/stream-large-file/README.md
+++ b/_examples/stream-large-file/README.md
@@ -7,12 +7,12 @@
 This project requires these tools to be installed globally.
 
 * wrangler
-* tinygo
+* Go 1.24.0 or later
 
 ### Commands
 
 ```
 make dev     # run dev server
 make build   # build Go Wasm binary
-make deploy # deploy worker
+make deploy  # deploy worker
 ```


### PR DESCRIPTION
# What

rewrote the examples provided to use the go instead of the tinygo compiler

# Motivation

closes #142