### PR TITLE
d1: fix RowsAffected() in sql.Result implementation

### DIFF
--- a/cloudflare/d1/result.go
+++ b/cloudflare/d1/result.go
@@ -2,7 +2,7 @@ package d1
 
 import (
 	"database/sql"
-	"errors"
+	"fmt"
 	"syscall/js"
 )
 
@@ -10,21 +10,24 @@ type result struct {
 	resultObj js.Value
 }
 
-var (
-	_ sql.Result = (*result)(nil)
-)
+var _ sql.Result = (*result)(nil)
 
 // LastInsertId returns id of result's last row.
-// If lastRowId can't be retrieved, this method returns error.
+// If 'last_row_id' can't be retrieved, this method returns error.
 func (r *result) LastInsertId() (int64, error) {
-	v := r.resultObj.Get("meta").Get("last_row_id")
-	if v.IsNull() || v.IsUndefined() {
-		return 0, errors.New("d1: lastRowId cannot be retrieved")
-	}
-	id := v.Int()
-	return int64(id), nil
+	return r.numberFromMeta("last_row_id")
 }
 
+// RowsAffected returns the number of rows affected by an update, insert, or delete.
+// If 'changes' can't be retrieved, this method returns error.
 func (r *result) RowsAffected() (int64, error) {
-	return int64(r.resultObj.Get("changes").Int()), nil
+	return r.numberFromMeta("changes")
+}
+
+func (r *result) numberFromMeta(key string) (int64, error) {
+	v := r.resultObj.Get("meta").Get(key)
+	if v.IsNull() || v.IsUndefined() {
+		return 0, fmt.Errorf("d1: '%s' cannot be retrieved", key)
+	}
+	return int64(v.Int()), nil
 }


### PR DESCRIPTION
# What

This change fixes `RowsAffected()` method on `sql.Result` interface implementation for D1.

# Motivation

`RowsAffected()` function is currently broken because it looks for `changes` in result before fetching `meta` first - this results in panic:
```
panic: syscall/js: call of Value.Int on undefined
goroutine 1 [running]:
syscall/js.Value.float({{}, 0x0, 0x0}, {0x940c0, 0x9})
	syscall/js/js.go:523 +0x10
syscall/js.Value.Int(...)
	syscall/js/js.go:540
github.com/syumai/workers/cloudflare/d1.(*result).RowsAffected(0x9032a0)
github.com/syumai/workers@v0.30.2/cloudflare/d1/result.go:29 +0x7
```
Docs states how the [D1Result](https://developers.cloudflare.com/d1/worker-api/return-object/#d1result) looks like.