### PR TITLE
fix: use Call instead of Get+Invoke in fetch to preserve `this` for service bindings

### DIFF
--- a/cloudflare/fetch/bind.go
+++ b/cloudflare/fetch/bind.go
@@ -15,8 +15,7 @@ func fetch(namespace js.Value, req *http.Request, init *RequestInit) (*http.Resp
 	if namespace.IsUndefined() {
 		return nil, errors.New("fetch function not found")
 	}
-	fetchFunc := namespace.Get("fetch")
-	promise := fetchFunc.Invoke(
+	promise := namespace.Call("fetch",
 		// The Request object to fetch.
 		// Docs: https://developers.cloudflare.com/workers/runtime-apis/request
 		jshttp.ToJSRequest(req),


### PR DESCRIPTION
## Problem

When using `WithBinding` to call a Cloudflare Service Binding's `fetch` method, the current implementation throws:

```
panic: JavaScript error: Illegal invocation: function called with incorrect `this` reference.
```

This happens because `bind.go` detaches the method before calling it:

```go
fetchFunc := namespace.Get("fetch")  // detaches method from object
promise := fetchFunc.Invoke(...)     // this === undefined → Illegal invocation
```

In JavaScript, `obj.method()` and `const f = obj.method; f()` behave differently. The latter loses `this`, which is required for service binding methods to identify the target Worker.

## Fix

Replace `Get("fetch").Invoke(...)` with `Call("fetch", ...)`, which is equivalent to `namespace.fetch(...)` in JavaScript and preserves the correct `this` reference:

```go
promise := namespace.Call("fetch", jsReq, init.ToJS())
```

This fix works correctly for both the global `fetch` (where `this` is `globalThis`) and service bindings (where `this` must be the binding object).

## Notes

- `js.Value.Call(m, args...)` is equivalent to JS `obj.method(args...)` — `this` is bound to `obj`
- `js.Value.Invoke(args...)` is equivalent to JS `fn(args...)` — `this` is `undefined` in strict mode
- The existing `DurableObjectStub.Fetch` in `dostub.go` already uses `.Call("fetch", ...)` correctly; this aligns `fetch/bind.go` with that pattern