### PR TITLE
fix run fetch failed

### DIFF
--- a/cmd/workers-assets-gen/assets/common/worker.mjs
+++ b/cmd/workers-assets-gen/assets/common/worker.mjs
@@ -3,6 +3,7 @@ import { createRuntimeContext, loadModule } from "./runtime.mjs";
 
 let mod;
 
+globalThis.fetch = globalThis.fetch.bind(globalThis);
 globalThis.tryCatch = (fn) => {
   try {
     return {


### PR DESCRIPTION
# What
panic: JavaScript error: Illegal invocation: function called with incorrect `this` reference. See https://developers.cloudflare.com/workers/observability/errors/#illegal-invocation-errors for details.

goroutine 10 [running]:
syscall/js.Value.Call({{}, 0x7ff8000100000005, 0x0}, {0x5d3f2, 0x5}, {0x493dd8, 0x2, 0x2})
	/home/labulakalia/sdk/go/src/syscall/js/js.go:443 +0x3b
github.com/syumai/workers/cloudflare/fetch.fetch({{}, 0x7ff8000100000005, 0x0}, 0x48c280, 0x493e60)
	/home/labulakalia/go/pkg/mod/github.com/syumai/workers@v0.32.0/cloudflare/fetch/bind.go:18 +0x7
github.com/syumai/workers/cloudflare/fetch.(*Client).Do(...)
	/home/labulakalia/go/pkg/mod/github.com/syumai/workers@v0.32.0/cloudflare/fetch/http.go:29
main.main.func1({0x9dd50, 0x482190}, 0x48c140)
	/home/labulakalia/workspace/testworker/main.go:23 +0x10
net/http.HandlerFunc.ServeHTTP(0x6a698, {0x9dd50, 0x482190}, 0x48c140)
	/home/labulakalia/sdk/go/src/net/http/server.go:2322 +0x4
net/http.(*ServeMux).ServeHTTP(0x2a7da0, {0x9dd50, 0x482190}, 0x48c140)
	/home/labulakalia/sdk/go/src/net/http/server.go:2861 +0x2e
github.com/syumai/workers.handleRequest.func1()
	/home/labulakalia/go/pkg/mod/github.com/syumai/workers@v0.32.0/handler_js.go:81 +0x4
created by github.com/syumai/workers.handleRequest in goroutine 9
	/home/labulakalia/go/pkg/mod/github.com/syumai/workers@v0.32.0/handler_js.go:78 +0x29


[illegal-invocation](https://developers.cloudflare.com/workers/observability/errors/#illegal-invocation-errors)

